### PR TITLE
<feat> : 로그인이메일 페이지 UI 구현

### DIFF
--- a/src/components/common/LabelInput/LabelInput.jsx
+++ b/src/components/common/LabelInput/LabelInput.jsx
@@ -1,0 +1,14 @@
+import { Label, Input, LabelInputWrap } from './StyledLabelInput';
+
+const LabelInput = (props) => {
+  const { label, forid, type, placeholder, className } = props;
+
+  return (
+    <LabelInputWrap className={className}>
+      <Label htmlFor={forid}>{label}</Label>
+      <Input type={type} id={forid} placeholder={placeholder} />
+    </LabelInputWrap>
+  );
+};
+
+export default LabelInput;

--- a/src/components/common/LabelInput/StyledLabelInput.jsx
+++ b/src/components/common/LabelInput/StyledLabelInput.jsx
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const LabelInputWrap = styled.div`
+  & + div {
+    margin-top: 16px;
+  }
+`;
+
+export const Label = styled.label`
+  display: block;
+  margin-bottom: 10px;
+  font-weight: 500;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  color: #767676;
+`;
+
+export const Input = styled.input`
+  display: block;
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid #dbdbdb;
+  padding-bottom: 8px;
+  ::placeholder {
+    font-family: 'Spoqa Han Sans Neo', sans-serif;
+    font-size: 1.4rem;
+    line-height: 1.4rem;
+    font-weight: 400;
+    color: #dbdbdb;
+  }
+  &:focus {
+    border-bottom: 1px solid #f5c045;
+    outline: none;
+  }
+`;

--- a/src/pages/LoginEmail/LoginEmail.jsx
+++ b/src/pages/LoginEmail/LoginEmail.jsx
@@ -1,5 +1,18 @@
+import LabelInput from '../../components/common/LabelInput/LabelInput';
+import * as S from './StyledLoginEmail';
+
 const LoginEmail = () => {
-  return <div>LoginEmail</div>;
+  return (
+    <S.LoginWrapper>
+      <S.LoginTitle>로그인</S.LoginTitle>
+      <form>
+        <LabelInput label='이메일' forid='email' type='email' />
+        <LabelInput label='비밀번호' forid='password' type='password' />
+        <S.LoginBtn name='로그인' />
+      </form>
+      <S.LoginLink to='/joinemail'>이메일로 회원가입</S.LoginLink>
+    </S.LoginWrapper>
+  );
 };
 
 export default LoginEmail;

--- a/src/pages/LoginEmail/StyledLoginEmail.jsx
+++ b/src/pages/LoginEmail/StyledLoginEmail.jsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import Button from '../../components/common/Button/Button';
+
+export const LoginWrapper = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const LoginTitle = styled.h1`
+  margin: 30px 0 40px;
+  font-weight: 500;
+  font-size: 2.4rem;
+  line-height: 3rem;
+`;
+
+export const LoginBtn = styled(Button)`
+  margin: 30px 0 20px;
+`;
+
+export const LoginLink = styled(Link)`
+  font-size: 1.2rem;
+  text-decoration: none;
+  line-height: 1.5rem;
+  color: #767676;
+`;


### PR DESCRIPTION
# <feat> : 로그인이메일 페이지 UI 구현

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/pages/LoginEmail/LoginEmail.jsx

## [📝 생성된 파일]
- src/components/common/LabelInput/LabelInput.jsx
- src/components/common/LabelInput/StyledLabelInput.jsx
- src/pages/LoginEmail/StyledLoginEmail.jsx


## [📌 제안 사항]

- 없음

## [📢 Notice]

- Button 컴포넌트에 className 추가 후 버튼 스타일 수정 예정
- 라벨 인풋 컴포넌트
<img width="308" alt="image" src="https://user-images.githubusercontent.com/96678570/208082768-e16062e7-e632-41d9-8ce7-381608441670.png">

- 로그인이메일 페이지 UI
<img width="321" alt="image" src="https://user-images.githubusercontent.com/96678570/208082826-7fa7be5d-55f1-450f-b00d-091e29467774.png">


