### PR TITLE
<feat> : 404page UI 구현

### DIFF
--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -1,5 +1,15 @@
+import * as S from './StyledNotFound';
+import Button from '../../components/common/Button/Button';
+import Img404 from '../../assets/images/icon-404.svg';
+
 const NotFound = () => {
-  return <div>NotFound</div>;
+  return (
+    <S.LayOut>
+      <img src={Img404} alt='페이지오류안내아이콘' />
+      <S.NotFoundMessage>페이지를 찾을 수 없습니다. :(</S.NotFoundMessage>
+      <Button type='button' name='이전 페이지' size='m' />
+    </S.LayOut>
+  );
 };
 
 export default NotFound;

--- a/src/pages/NotFound/StyledNotFound.jsx
+++ b/src/pages/NotFound/StyledNotFound.jsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const LayOut = styled.div`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const NotFoundMessage = styled.span`
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 1.4rem;
+  color: #767676;
+`;


### PR DESCRIPTION
# (커밋 메시지 헤더와 동일하게 작성)

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/pages/NotFound/NotFound

## [📝 생성된 파일]

- src/pages/NotFound/StyledNotFound

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 디테일한 스타일 수정이 필요합니다. 추후 리펙토링하겠습니다.
- 404page ui
<img width="567" alt="image" src="https://user-images.githubusercontent.com/89332492/208161634-d0f91927-b6a3-4ed5-9ecf-e1b5aede3835.png">
- close #38
