### PR TITLE
<feat> : 프로필이미지, 코멘트 입력창 UI 구현

### DIFF
--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -1,0 +1,25 @@
+import ProfileImg from '../common/ProfileImg/ProfileImg';
+import basicProfileImg from '../../assets/images/profile-image.svg';
+import * as S from './StyledComment';
+import verticalIcon from '../../assets/images/icon-more-vertical.svg';
+
+const Comment = () => {
+  return (
+    <>
+      <S.CommentUserInfo>
+        <ProfileImg size='36px' src={basicProfileImg} alt='프로필이미지' />
+        <S.UserInfo>
+          <strong>서귀포시 무슨 농장</strong>
+          <p>· 5분 전</p>
+          <img src={verticalIcon} alt='댓글 수정 메뉴 버튼' />
+        </S.UserInfo>
+      </S.CommentUserInfo>
+      <S.CommentContent>
+        안녕하세요. 사진이 너무 멋있어요. 한라봉 언제먹을 수 있나요? 기다리기
+        지쳤어요 땡뻘땡뻘..
+      </S.CommentContent>
+    </>
+  );
+};
+
+export default Comment;

--- a/src/components/Comment/StyledComment.jsx
+++ b/src/components/Comment/StyledComment.jsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+export const CommentUserInfo = styled.div`
+  display: flex;
+  gap: 12px;
+  position: relative;
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  gap: 6px;
+  padding-top: 6px;
+  text-align: center;
+
+  strong {
+    font-size: 1.4rem;
+    font-weight: 500;
+  }
+
+  p {
+    color: #767676;
+    padding-top: 2.5px;
+  }
+
+  img {
+    position: absolute;
+    right: 0;
+    top: 2px;
+    width: 20px;
+  }
+`;
+
+export const CommentContent = styled.p`
+  padding: 4px 0 0 48px;
+  font-size: 1.4rem;
+  line-height: 1.753rem;
+  color: #333333;
+`;

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -1,0 +1,18 @@
+import ProfileImg from '../common/ProfileImg/ProfileImg';
+import basicProfileImg from '../../assets/images/profile-image.svg';
+import * as S from './StyledCommentInput';
+
+const CommentInput = () => {
+  return (
+    <S.CommentWrapper>
+      <ProfileImg size='36px' src={basicProfileImg} alt='프로필이미지' />
+      {/* <label htmlFor='comment' className='hidden'>
+        댓글입력창
+      </label> */}
+      <S.CommentInput id='comment' />
+      <S.CommentUploadBtn type='button'>게시</S.CommentUploadBtn>
+    </S.CommentWrapper>
+  );
+};
+
+export default CommentInput;

--- a/src/components/CommentInput/StyledCommentInput.jsx
+++ b/src/components/CommentInput/StyledCommentInput.jsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const CommentWrapper = styled.form`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 13px 16px;
+  border-top: 0.5px solid #dbdbdb;
+`;
+
+export const CommentInput = styled.input.attrs({
+  type: 'text',
+  placeholder: '댓글 입력하기...',
+  autoComplete: 'off',
+})`
+  &::placeholder {
+    color: #c4c4c4;
+    font-size: 1.4rem;
+    font-family: 'Spoqa Han Sans Neo', sans-serif;
+  }
+  font-size: 1.4rem;
+  width: 100%;
+  border: none;
+`;
+
+export const CommentUploadBtn = styled.button`
+  color: #c4c4c4;
+  font-size: 1.4rem;
+  line-height: 1.753rem;
+  font-weight: 500;
+  white-space: nowrap;
+`;

--- a/src/components/common/ProfileImg/ProfileImg.jsx
+++ b/src/components/common/ProfileImg/ProfileImg.jsx
@@ -1,0 +1,11 @@
+import StyledProfileImg from './StyledProfileImg';
+
+const ProfileImg = ({ size, src, alt }) => {
+  return <StyledProfileImg size={size} src={src} alt={alt} />;
+};
+
+ProfileImg.defaultProps = {
+  src: '../assets/images/profile-img.svg',
+};
+
+export default ProfileImg;

--- a/src/components/common/ProfileImg/StyledProfileImg.jsx
+++ b/src/components/common/ProfileImg/StyledProfileImg.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+const StyledProfileImg = styled.img`
+  width: ${(props) => props.size};
+  height: ${(props) => props.size};
+  border-radius: 50%;
+`;
+
+export default StyledProfileImg;

--- a/src/pages/PostDetail/PostDetail.jsx
+++ b/src/pages/PostDetail/PostDetail.jsx
@@ -1,5 +1,13 @@
+import Comment from '../../components/Comment/Comment';
+import CommentInput from '../../components/CommentInput/CommentInput';
+
 const PostDetail = () => {
-  return <div>PostDetail</div>;
+  return (
+    <>
+      <Comment />
+      <CommentInput />
+    </>
+  );
 };
 
 export default PostDetail;


### PR DESCRIPTION
<feat> : 프로필이미지, 코멘트 입력창 UI 구현

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- 없음

## [📝 생성된 파일]

- src/components/Comment/Comment.jsx
- src/components/Comment/StyledComment.jsx
- src/components/CommentInput/CommentInput.jsx
- src/components/CommentInput/StyledCommentInput.jsx
- src/components/common/ProfileImg/ProfileImg.jsx
- src/components/common/ProfileImg/StyledProfileImg.jsx

## [📌 제안 사항]

- CommentInput 컴포넌트의 라벨-인풋 id 에러로 라벨요소는 주석처리한 상황이며 추후 리팩토링 예정입니다.

## [📢 Notice]

- 프로필(이미지) 공통 컴포넌트
![image](https://user-images.githubusercontent.com/102464638/208234323-2bf58696-e053-468f-b3e3-984f88570bb6.png)

- 댓글 인풋창 컴포넌트
![image](https://user-images.githubusercontent.com/102464638/208234350-70181890-faf2-40ee-b716-678bcdb398b1.png)

- 댓글 업로드 UI
![image](https://user-images.githubusercontent.com/102464638/208234386-39273778-8f7f-41df-9554-509a9202451d.png)

close #31 