### PR TITLE
<feat> : JoinProfileEdit 페이지 UI 구현

### DIFF
--- a/src/components/common/ImageInput/ImageInput.jsx
+++ b/src/components/common/ImageInput/ImageInput.jsx
@@ -1,0 +1,19 @@
+import EggProfile from '../../../assets/images/profile-image.svg';
+import UploadImgIcon from '../../../assets/images/upload-file.svg';
+import ImageInputWrap from './StyledImageInput';
+
+const ImageInput = (props) => {
+  const { className } = props;
+
+  return (
+    <ImageInputWrap className={className}>
+      <img src={EggProfile} alt='프로필 이미지' />
+      <label htmlFor='profileImg'>
+        <img src={UploadImgIcon} alt='프로필 이미지 선택 아이콘' />
+      </label>
+      <input type='file' id='profileImg' className='hidden' />
+    </ImageInputWrap>
+  );
+};
+
+export default ImageInput;

--- a/src/components/common/ImageInput/StyledImageInput.jsx
+++ b/src/components/common/ImageInput/StyledImageInput.jsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+const ImageInputWrap = styled.div`
+  position: relative;
+  width: 110px;
+  margin: 0 auto 30px;
+
+  & > img {
+    width: 100%;
+  }
+
+  label > img {
+    position: absolute;
+    top: 74px;
+    left: 74px;
+    width: 36px;
+    cursor: pointer;
+  }
+`;
+
+export default ImageInputWrap;

--- a/src/pages/JoinProfileEdit/JoinProfileEdit.jsx
+++ b/src/pages/JoinProfileEdit/JoinProfileEdit.jsx
@@ -1,5 +1,36 @@
+import ImageInput from '../../components/common/ImageInput/ImageInput';
+import LabelInput from '../../components/common/LabelInput/LabelInput';
+import * as S from './StyledJoinProfileEdit';
+
 const JoinProfileEdit = () => {
-  return <div>JoinProfileEdit</div>;
+  return (
+    <S.JoinPfWrap>
+      <S.JoinPfTitle>프로필 설정</S.JoinPfTitle>
+      <S.JoinPfDesc>나중에 언제든지 변경할 수 있습니다.</S.JoinPfDesc>
+      <form>
+        <ImageInput />
+        <LabelInput
+          label='사용자 이름'
+          forid='username'
+          type='text'
+          placeholder='2~10자 이내여야 합니다.'
+        />
+        <LabelInput
+          label='계정 ID'
+          forid='userid'
+          type='text'
+          placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+        />
+        <LabelInput
+          label='소개'
+          forid='intro'
+          type='text'
+          placeholder='자신과 판매할 상품에 대해 소개해 주세요!'
+        />
+        <S.JoinPfBtn name='감귤마켓 시작하기' />
+      </form>
+    </S.JoinPfWrap>
+  );
 };
 
 export default JoinProfileEdit;

--- a/src/pages/JoinProfileEdit/StyledJoinProfileEdit.jsx
+++ b/src/pages/JoinProfileEdit/StyledJoinProfileEdit.jsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import Button from '../../components/common/Button/Button';
+
+export const JoinPfWrap = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const JoinPfTitle = styled.h1`
+  margin: 30px 0 12px;
+  font-size: 2.4rem;
+  font-weight: 500;
+  line-height: 3rem;
+`;
+
+export const JoinPfDesc = styled.p`
+  margin-bottom: 30px;
+  font-size: 1.4rem;
+  color: #767676;
+`;
+
+export const JoinPfBtn = styled(Button)`
+  margin-top: 30px;
+`;


### PR DESCRIPTION
# <feat> : JoinProfileEdit 페이지 UI 구현

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/pages/JoinProfileEdit/JoinProfileEdit.jsx

## [📝 생성된 파일]

- src/pages/JoinProfileEdit/StyledJoinProfileEdit.jsx
- src/components/common/ImageInput/ImageInput.jsx
- src/components/common/ImageInput/StyledImageInput.jsx

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 구현 UI
<img width="223" alt="image" src="https://user-images.githubusercontent.com/96678570/208245453-e59140ad-c7cc-4c5a-aed6-cfa0a7a385e6.png">


- ImageInput 컴포넌트 (프로필 수정 페이지에서도 재사용되어 컴포넌트로 분리해보았습니다.)
<img width="88" alt="image" src="https://user-images.githubusercontent.com/96678570/208245409-1f7a8b27-a60a-4a1d-9cb3-a86c33e1a20e.png">

- Button 컴포넌트에 className 추가 후 버튼 스타일 수정 예정