### PR TITLE
<feat> : 하단 탭 메뉴 페이지 이동 및 버튼활성화 & 글로벌스타일수정

### DIFF
--- a/src/components/common/TabMenu/StyledTabMenu.jsx
+++ b/src/components/common/TabMenu/StyledTabMenu.jsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
+import { NavLink } from 'react-router-dom';
 
 export const MenuWrapper = styled.ul`
   display: flex;
-  flex-direction: row;
   justify-content: space-around;
+  position: fixed;
+  bottom: 0;
   width: 100%;
   height: 60px;
   background: #ffffff;
@@ -11,14 +13,22 @@ export const MenuWrapper = styled.ul`
 `;
 
 export const MenuList = styled.li`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   width: 84px;
+  text-align: center;
   cursor: pointer;
   font-size: 1rem;
   font-weight: 400;
   line-height: 14px;
+`;
+
+export const MenuNavLink = styled(NavLink)`
+  color: var(-----sub-text-color);
+  font-size: 1rem;
+  line-height: 1.4rem;
+
+  &.active {
+    color: var(--main-color);
+  }
 `;
 
 export const MenuImg = styled.img`

--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -1,28 +1,80 @@
-import * as S from './StyledTabMenu';
+// import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
+// import { AuthContext } from '../../../context/context';
 import iconHome from '../../../assets/images/icon-home.svg';
+import activeIconHome from '../../../assets/images/icon-home-fill.svg';
 import iconMessageCircle from '../../../assets/images/icon-message-circle.svg';
+import activeIconMessageCircle from '../../../assets/images/icon-message-circle-fill.svg';
 import iconEdit from '../../../assets/images/icon-edit.svg';
 import iconUser from '../../../assets/images/icon-user.svg';
+import activeIconUser from '../../../assets/images/icon-user-fill.svg';
+import * as S from './StyledTabMenu';
 
 const TabMenu = () => {
+  const location = useLocation();
+
+  // const { user } = useContext(AuthContext);
+
   return (
     <S.MenuWrapper>
-      <S.MenuList>
-        <S.MenuImg src={iconHome} alt='홈탭' />
-        <p>홈</p>
-      </S.MenuList>
-      <S.MenuList>
-        <S.MenuImg src={iconMessageCircle} alt='채팅탭' />
-        <p>채팅</p>
-      </S.MenuList>
-      <S.MenuList>
-        <S.MenuImg src={iconEdit} alt='게시물작성탭' />
-        <p>게시물 작성</p>
-      </S.MenuList>
-      <S.MenuList>
-        <S.MenuImg src={iconUser} alt='프로필탭' />
-        <p>프로필</p>
-      </S.MenuList>
+      {/* 홈으로 이동 */}
+      <S.MenuNavLink
+        to='/homefeed'
+        className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+      >
+        <S.MenuList>
+          <S.MenuImg
+            src={location.pathname === '/homefeed' ? activeIconHome : iconHome}
+            alt='홈탭'
+          />
+          <p>홈</p>
+        </S.MenuList>
+      </S.MenuNavLink>
+
+      {/* 채팅으로 이동 */}
+
+      <S.MenuNavLink to='/chatroom'>
+        <S.MenuList>
+          <S.MenuImg
+            src={
+              location.pathname === '/chatroom'
+                ? activeIconMessageCircle
+                : iconMessageCircle
+            }
+            alt='채팅탭'
+          />
+          <p>채팅</p>
+        </S.MenuList>
+      </S.MenuNavLink>
+
+      {/* 게시물 작성페이지로 이동 */}
+
+      <S.MenuNavLink to='/uploadpost'>
+        <S.MenuList>
+          <S.MenuImg src={iconEdit} alt='게시물작성탭' />
+          <p>게시물 작성</p>
+        </S.MenuList>
+      </S.MenuNavLink>
+
+      {/* 로그인한 유저의 프로필 페이지로 이동 */}
+      {/* <S.MenuNavLink to={`/myprofile/${user.accountname}`}> */}
+      <S.MenuNavLink to='/myprofile'>
+        <S.MenuList>
+          <S.MenuImg
+            src={location.pathname === `/myprofile` ? activeIconUser : iconUser}
+            alt='프로필탭'
+          />
+          {/* <S.MenuImg
+            src={
+              location.pathname === `/myprofile/${user.accountname}`
+                ? activeIconUser
+                : iconUser
+            }
+            alt='프로필탭'
+          /> */}
+          <p>프로필</p>
+        </S.MenuList>
+      </S.MenuNavLink>
     </S.MenuWrapper>
   );
 };

--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -18,23 +18,23 @@ const TabMenu = () => {
   return (
     <S.MenuWrapper>
       {/* 홈으로 이동 */}
-      <S.MenuNavLink
-        to='/homefeed'
-        className={({ isActive }) => (isActive ? 'active' : 'inactive')}
-      >
-        <S.MenuList>
+      <S.MenuList>
+        <S.MenuNavLink
+          to='/homefeed'
+          className={({ isActive }) => (isActive ? 'active' : 'inactive')}
+        >
           <S.MenuImg
             src={location.pathname === '/homefeed' ? activeIconHome : iconHome}
             alt='홈탭'
           />
           <p>홈</p>
-        </S.MenuList>
-      </S.MenuNavLink>
+        </S.MenuNavLink>
+      </S.MenuList>
 
       {/* 채팅으로 이동 */}
 
-      <S.MenuNavLink to='/chatroom'>
-        <S.MenuList>
+      <S.MenuList>
+        <S.MenuNavLink to='/chatroom'>
           <S.MenuImg
             src={
               location.pathname === '/chatroom'
@@ -44,22 +44,22 @@ const TabMenu = () => {
             alt='채팅탭'
           />
           <p>채팅</p>
-        </S.MenuList>
-      </S.MenuNavLink>
+        </S.MenuNavLink>
+      </S.MenuList>
 
       {/* 게시물 작성페이지로 이동 */}
 
-      <S.MenuNavLink to='/uploadpost'>
-        <S.MenuList>
+      <S.MenuList>
+        <S.MenuNavLink to='/uploadpost'>
           <S.MenuImg src={iconEdit} alt='게시물작성탭' />
           <p>게시물 작성</p>
-        </S.MenuList>
-      </S.MenuNavLink>
+        </S.MenuNavLink>
+      </S.MenuList>
 
       {/* 로그인한 유저의 프로필 페이지로 이동 */}
       {/* <S.MenuNavLink to={`/myprofile/${user.accountname}`}> */}
-      <S.MenuNavLink to='/myprofile'>
-        <S.MenuList>
+      <S.MenuList>
+        <S.MenuNavLink to='/myprofile'>
           <S.MenuImg
             src={location.pathname === `/myprofile` ? activeIconUser : iconUser}
             alt='프로필탭'
@@ -73,8 +73,8 @@ const TabMenu = () => {
             alt='프로필탭'
           /> */}
           <p>프로필</p>
-        </S.MenuList>
-      </S.MenuNavLink>
+        </S.MenuNavLink>
+      </S.MenuList>
     </S.MenuWrapper>
   );
 };

--- a/src/pages/MyProfile/StyledMyProfile.jsx
+++ b/src/pages/MyProfile/StyledMyProfile.jsx
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+
+export const Container = styled.section`
+  width: 390px;
+  height: 314px;
+  border: 0.5px solid #dbdbdb;
+`;
+
+export const ProfileInfoWrapper = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+
+  span:nth-child(2) {
+    margin-top: 6px;
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 12px;
+    color: #767676;
+  }
+`;
+
+export const NumberWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+`;
+
+export const NumberOfFollowers = styled.span`
+  margin-top: 65px;
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 23px;
+`;
+
+export const NumberOfFollowings = styled(NumberOfFollowers)`
+  color: #767676;
+`;
+
+export const ProfileImg = styled.img`
+  margin-top: 30px;
+  width: 111px;
+  height: 111px;
+  border-radius: 50%;
+`;
+
+export const UserWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 15px 0 24px 0;
+`;
+
+export const UserName = styled.strong`
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 20px;
+`;
+export const UserId = styled.p`
+  margin-top: 6px;
+  font-size: 1.2rem;
+  color: #767676;
+  line-height: 14px;
+`;
+
+export const UserDescription = styled.p`
+  margin: 16px 0 0 0;
+  font-size: 1.4rem;
+  line-height: 18px;
+  color: #767676;
+`;
+
+export const BtnWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 0 26px 0;
+`;
+

--- a/src/styles/Globalstyled.jsx
+++ b/src/styles/Globalstyled.jsx
@@ -33,6 +33,11 @@ const GlobalStyled = createGlobalStyle`
     font: inherit;
     
   }
+  a {
+    color: #fff; 
+    text-decoration: none; 
+    outline: none
+  }
   .hidden {
     position: absolute;
     clip-path: inset(50%);


### PR DESCRIPTION
# <feat> : 하단 탭 메뉴 페이지 이동 및 버튼활성화 & 글로벌스타일수정

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

-  src/components/common/TabMenu/StyledTabMenu.jsx
- src/components/common/TabMenu/TabMenu.jsx
- src/styles/Globalstyled.jsx

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 채팅페이지는 아직 UI 완성되지 않아서 완성되면 기능 테스트 다시 해볼 예정
- src/pages/MyProfile/StyledMyProfile.jsx 이 파일은 무시 부탁드립니다.(myProfile 브랜치에서 작업하던거였는데..
어떻게 갑자기 꼽사리 껴서 푸시가 된건지를 모르겠습니다...ㅠ)

## [📢 Notice]
- position:fixed를 적용하여 탭 메뉴를 하단에 고정시켰음
-  하단 탭 메뉴 클릭시 해당 페이지로 이동 및 해당 메뉴 버튼(이미지,글꼴) 활성화
- 글로벌스타일드 a태그 스타일 초기화하였음
- UseNavigate 대신에, Link에 스타일을 주면 변형할 수 있는 NavLink 를 사용하였습니다. 
- 추후 myprofile 페이지 라우터 수정이된다면(개인프로필페이지로 접근하는 라우터) useContext 주석 해제할 예정입니다.

![탭메뉴](https://user-images.githubusercontent.com/107895498/208920408-12c54b63-04fa-44ec-8dc5-c26129273449.gif)

