### PR TITLE
<feat> : MyProfile page UI 구현 

### DIFF
--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,10 +1,36 @@
-import * as S from './StyledProfileInfo';
+import { useLocation } from 'react-router-dom';
 import Button from '../common/Button/Button';
 import profileImg from '../../assets/images/profile-image.svg';
 import iconMessageCircle from '../../assets/images/icon-message-circle.svg';
 import iconShare from '../../assets/images/icon-share.svg';
+import * as S from './StyledProfileInfo';
+
+const YourProfileBtnWrap = () => {
+  return (
+    <S.BtnWrapper>
+      <S.Btn>
+        <img src={iconMessageCircle} alt='메세지아이콘' />
+      </S.Btn>
+      <Button name='팔로우' type='button' size='m' />
+      <S.Btn>
+        <img src={iconShare} alt='공유아이콘' />
+      </S.Btn>
+    </S.BtnWrapper>
+  );
+};
+
+const MyProfileBtnWrap = () => {
+  return (
+    <S.BtnWrapper>
+      <Button name='프로필 수정' type='button' size='m' />
+      <Button name='상품 등록' type='button' size='m' />
+    </S.BtnWrapper>
+  );
+};
 
 const ProfileInfo = () => {
+  const location = useLocation();
+  console.log(location);
   return (
     <S.Container>
       <S.ProfileInfoWrapper>
@@ -26,15 +52,11 @@ const ProfileInfo = () => {
           감귤 전국 배송, 귤따기 체험, 감귤 농장
         </S.UserDescription>
       </S.UserWrapper>
-      <S.BtnWrapper>
-        <S.Btn>
-          <img src={iconMessageCircle} alt='메세지아이콘' />
-        </S.Btn>
-        <Button name='팔로우' type='button' size='m' />
-        <S.Btn>
-          <img src={iconShare} alt='공유아이콘' />
-        </S.Btn>
-      </S.BtnWrapper>
+      {location.pathname === '/yourprofile' ? (
+        <YourProfileBtnWrap />
+      ) : (
+        <MyProfileBtnWrap />
+      )}
     </S.Container>
   );
 };

--- a/src/pages/MyProfile/MyProfile.jsx
+++ b/src/pages/MyProfile/MyProfile.jsx
@@ -1,13 +1,32 @@
+import Nav from '../../components/Nav/Nav';
 import Product from '../../components/common/Product/Product';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
-// import * as S from './StyledMyProfile';
+import ProfileInfo from '../../components/ProfileInfo/ProfileInfo';
+import MenuBar from '../../components/MenuBar/MenuBar';
+import PostCard from '../../components/common/PostCard/PostCard';
+import * as S from '../YourProfile/StyledYourProfile';
 
 const MyProfile = () => {
   return (
-    <div>
-      <Product />
+    <>
+      <Nav type='home' />
+      <S.MainWrap>
+        <ProfileInfo />
+        <S.ProductsSection>
+          <h2>판매 중인 상품</h2>
+          <div>
+            <Product />
+            <Product />
+            <Product />
+          </div>
+        </S.ProductsSection>
+        <MenuBar />
+        <S.PostCardWrap>
+          <PostCard />
+        </S.PostCardWrap>
+      </S.MainWrap>
       <TabMenu />
-    </div>
+    </>
   );
 };
 

--- a/src/pages/MyProfile/MyProfile.jsx
+++ b/src/pages/MyProfile/MyProfile.jsx
@@ -1,5 +1,6 @@
 import Product from '../../components/common/Product/Product';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
+// import * as S from './StyledMyProfile';
 
 const MyProfile = () => {
   return (

--- a/src/pages/MyProfile/StyledMyProfile.jsx
+++ b/src/pages/MyProfile/StyledMyProfile.jsx
@@ -75,4 +75,3 @@ export const BtnWrapper = styled.div`
   gap: 10px;
   margin: 0 0 26px 0;
 `;
-

--- a/src/pages/YourProfile/StyledYourProfile.jsx
+++ b/src/pages/YourProfile/StyledYourProfile.jsx
@@ -1,9 +1,11 @@
 import styled from 'styled-components';
 
+export const MainWrap = styled.main`
+  width: 390px;
+  margin: 0 auto;
+`;
 export const ProductsSection = styled.section`
   padding: 20px 0 20px 16px;
-  width: 390px;
-  /* height: 208px; */
   border: 0.5px solid #dbdbdb;
   overflow: hidden;
   h2 {
@@ -18,9 +20,14 @@ export const ProductsSection = styled.section`
   }
 `;
 
-export const ProfilePostCardWrap = styled.section`
-  padding: 1.6rem 1.6rem 3rem 1.6rem;
+/* padding-bottom 부분을 9rem으로 한 이유는 하단 탭메뉴가
+position:fixed로 고정되어있어서 고정될 시 안에 컨텐츠가 탭메뉴와
+겹쳐보이는 현상을 방지하기 위해서 탭메뉴 높이만큼 padding-bottom
+부분을 추가해주었음 */
+export const PostCardWrap = styled.section`
+  padding: 1.6rem 1.6rem 9rem 1.6rem;
   width: 390px;
+  border: 0.5px solid #dbdbdb;
 `;
 
 export const ProfilePostAlbumWrap = styled.ul`

--- a/src/pages/YourProfile/StyledYourProfile.jsx
+++ b/src/pages/YourProfile/StyledYourProfile.jsx
@@ -7,7 +7,7 @@ export const MainWrap = styled.main`
 export const ProductsSection = styled.section`
   padding: 20px 0 20px 16px;
   border: 0.5px solid #dbdbdb;
-  overflow: hidden;
+  overflow-x: scroll;
   h2 {
     margin-bottom: 16px;
     font-size: 1.6rem;

--- a/src/pages/YourProfile/YourProfile.jsx
+++ b/src/pages/YourProfile/YourProfile.jsx
@@ -11,26 +11,30 @@ const YourProfile = () => {
   return (
     <>
       <Nav type='home' />
-      <ProfileInfo />
-      <S.ProductsSection>
-        <h2>판매 중인 상품</h2>
-        <div>
-          <Product />
-          <Product />
-          <Product />
-        </div>
-      </S.ProductsSection>
-      <MenuBar />
-      <PostCard />
-      <S.ProfilePostCardWrap>
-        <h2 className='hidden'>SNS 이미지 리스트</h2>
-        <S.ProfilePostAlbumWrap>
-          {/* 사진 데이터들어오면 아래 사진데이터는 리팩토링될 예정 */}
-          {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(() => {
-            return <img src={postSquareImgExample} alt='정방형 이미지' />;
-          })}
-        </S.ProfilePostAlbumWrap>
-      </S.ProfilePostCardWrap>
+      <S.MainWrap>
+        <ProfileInfo />
+        <S.ProductsSection>
+          <h2>판매 중인 상품</h2>
+          <div>
+            <Product />
+            <Product />
+            <Product />
+          </div>
+        </S.ProductsSection>
+        <MenuBar />
+        <S.PostCardWrap>
+          <PostCard />
+        </S.PostCardWrap>
+        <S.PostCardWrap>
+          <h2 className='hidden'>SNS 이미지 리스트</h2>
+          <S.ProfilePostAlbumWrap>
+            {/* 사진 데이터들어오면 아래 사진데이터는 리팩토링될 예정 */}
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(() => {
+              return <img src={postSquareImgExample} alt='정방형 이미지' />;
+            })}
+          </S.ProfilePostAlbumWrap>
+        </S.PostCardWrap>
+      </S.MainWrap>
       <TabMenu />
     </>
   );


### PR DESCRIPTION
# <feat> : MyProfile page UI 구현

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/components/ProfileInfo/ProfileInfo.jsx
- src/pages/MyProfile/MyProfile.jsx
- src/pages/YourProfile/StyledYourProfile.jsx
- src/pages/YourProfile/YourProfile.jsx

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 버튼에 관련된 기능구현 및 색깔은 프로필 기능 구현 담당자분께서 리팩토링 담당해주시면 되겠습니다!
- style에서 테두리 border는 알아보기 쉽게 하기위해 설정하였으며 다음 담당자분께서는 기능구현 완료 후 피그마에 맞게 지워주시면 됩니다~~!

## [📢 Notice]
- 프로필 페이지 메인 부분을 가운데 정렬하였음
- ProfileInfo 공통컴포넌트 부분에서 useLocation 과 삼항연산자를 이용하여 yourprofile 페이지일 경우에 버튼 1개
- myprofile 페이지일 경우에 버튼 2개를 보여주는 기능을 구현하였음
- 아래 이미지의 빨간색 박스부분 참고 부탁드립니다!

1) myprofile 페이지
![image](https://user-images.githubusercontent.com/107895498/209080323-583abfdf-9a7a-4a1c-910b-55618c85119c.png)

2) yourprofile 페이지
![image](https://user-images.githubusercontent.com/107895498/209080432-b61c0b45-2c0e-439d-a1ed-f2b0f2c3c2d8.png)

