### PR TITLE
<refact> : page UI & Layout 및 common component 수정

### DIFF
--- a/src/components/Nav/ChatNav.jsx
+++ b/src/components/Nav/ChatNav.jsx
@@ -1,26 +1,18 @@
-import styled from 'styled-components';
 import * as S from './StyledNav';
 import MoreImg from '../../assets/images/icon-more-vertical.svg';
 import ArrowImg from '../../assets/images/icon-arrow-left.svg';
 
-const Text = styled.span`
-  flex-grow: 2;
-  font-size: 18px;
-  font-weight: 500;
-  line-height: 22px;
-  margin-left: 10px;
-`;
-
 const ChatNav = () => {
   return (
     <>
-      <S.BtnWrapp>
+      {/* <h2 className='hidden'>채팅 페이지</h2> */}
+      <button type='button'>
         <S.BackIcon src={ArrowImg} alt='뒤로가기버튼' />
-      </S.BtnWrapp>
-      <Text>대화 상대 닉네임</Text>
-      <S.BtnWrapp>
+      </button>
+      <S.HeaderTitle>대화 상대 닉네임</S.HeaderTitle>
+      <button type='button'>
         <S.MoreIcon src={MoreImg} alt='더보기버튼' />
-      </S.BtnWrapp>
+      </button>
     </>
   );
 };

--- a/src/components/Nav/FollowHeader.jsx
+++ b/src/components/Nav/FollowHeader.jsx
@@ -1,16 +1,16 @@
 import * as S from './StyledNav';
 import ArrowImg from '../../assets/images/icon-arrow-left.svg';
 
-const SearchNav = () => {
+const FollowersHeader = () => {
   return (
     <>
-      {/* <h2 className='hidden'>검색입력</h2> */}
+      {/* <h2 className='hidden'>팔로워 목록 페이지</h2> */}
       <button type='button'>
         <S.BackIcon src={ArrowImg} alt='뒤로가기버튼' />
       </button>
-      <S.StyledInput type='text' id='search' placeholder='계정 검색' />
+      <S.HeaderTitle>Followers</S.HeaderTitle>
     </>
   );
 };
 
-export default SearchNav;
+export default FollowersHeader;

--- a/src/components/Nav/HomeNav.jsx
+++ b/src/components/Nav/HomeNav.jsx
@@ -5,12 +5,13 @@ import ArrowImg from '../../assets/images/icon-arrow-left.svg';
 const HomeNav = () => {
   return (
     <>
-      <S.BtnWrapp>
+      {/* <h2 className='hidden'>뒤로가기,더보기 메뉴</h2> */}
+      <button type='button'>
         <S.BackIcon src={ArrowImg} alt='뒤로가기버튼' />
-      </S.BtnWrapp>
-      <S.BtnWrapp>
+      </button>
+      <button type='button'>
         <S.MoreIcon src={MoreImg} alt='더보기버튼' />
-      </S.BtnWrapp>
+      </button>
     </>
   );
 };

--- a/src/components/Nav/MainNav.jsx
+++ b/src/components/Nav/MainNav.jsx
@@ -1,13 +1,20 @@
+import styled from 'styled-components';
 import * as S from './StyledNav';
 import SearchImg from '../../assets/images/icon-search.svg';
+
+const Title = styled.span`
+  font-size: 18px;
+  font-weight: 500;
+`;
 
 const MainNav = () => {
   return (
     <>
-      <S.Text>노나먹자 피드</S.Text>
-      <S.BtnWrapp>
+      {/* <h2 className='hidden'>노나먹자 이용자검색</h2> */}
+      <Title>노나먹자 피드</Title>
+      <button type='button'>
         <S.SearchIcon src={SearchImg} alt='뒤로가기버튼' />
-      </S.BtnWrapp>
+      </button>
     </>
   );
 };

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -3,7 +3,8 @@ import SearchNav from './SearchNav';
 import MainNav from './MainNav';
 import UploadNav from './UploadNav';
 import ChatNav from './ChatNav';
-import { NavWrapp } from './StyledNav';
+import FollowHeader from './FollowHeader';
+import { HeaderWrapp } from './StyledNav';
 
 const Nav = ({ type, btnName }) => {
   const NAV = {
@@ -12,9 +13,10 @@ const Nav = ({ type, btnName }) => {
     main: <MainNav />,
     upload: <UploadNav btnName={btnName} />,
     chat: <ChatNav />,
+    follow: <FollowHeader />,
   };
 
-  return <NavWrapp>{NAV[type]}</NavWrapp>;
+  return <HeaderWrapp>{NAV[type]}</HeaderWrapp>;
 };
 
 export default Nav;

--- a/src/components/Nav/StyledNav.jsx
+++ b/src/components/Nav/StyledNav.jsx
@@ -2,14 +2,14 @@ import styled from 'styled-components';
 
 // 시멘틱태그를 최대한 활용하려다보니 이게 맞는지 모르겄네 아니면 <Header> 태그 사용이 맞을지..?
 const HeaderWrapp = styled.header`
-  width: 100%;
+  display: flex;
   position: sticky;
   top: 0;
+  width: 100%;
   height: 48px;
-  display: flex;
+  padding: 8px 16px;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px;
   background-color: var(--main-text-color);
   border-bottom: 0.5px solid var(--border-color);
   z-index: 10;

--- a/src/components/Nav/StyledNav.jsx
+++ b/src/components/Nav/StyledNav.jsx
@@ -1,32 +1,29 @@
 import styled from 'styled-components';
 
 // 시멘틱태그를 최대한 활용하려다보니 이게 맞는지 모르겄네 아니면 <Header> 태그 사용이 맞을지..?
-const NavWrapp = styled.nav`
+const HeaderWrapp = styled.header`
   width: 100%;
+  position: sticky;
+  top: 0;
   height: 48px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 16px 8px 12px;
-  background-color: #fff;
-  border-bottom: 0.5px solid #dbdbdb;
+  padding: 8px 16px;
+  background-color: var(--main-text-color);
+  border-bottom: 0.5px solid var(--border-color);
 `;
 
-// 임시 컴포넌트: 속성, 컴포넌트 네임 수정필요
-const Text = styled.span`
-  font-size: 18px;
+const HeaderTitle = styled.span`
+  flex-grow: 2;
+  font-size: 1.8rem;
   font-weight: 500;
-  line-height: 22px;
-`;
-
-// button -> Link 기능으로 수정하는게 맞나?
-const BtnWrapp = styled.button`
-  /* padding-left: 삭제예정*/
+  margin-left: 10px;
 `;
 
 // input styled
 const StyledInput = styled.input`
-  width: 316px;
+  width: 322px;
   height: 32px;
   background-color: #f2f2f2;
   border-radius: 32px;
@@ -49,11 +46,10 @@ const SearchIcon = styled.img`
 `;
 
 export {
-  NavWrapp,
-  BtnWrapp,
+  HeaderWrapp,
   BackIcon,
   MoreIcon,
   SearchIcon,
   StyledInput,
-  Text,
+  HeaderTitle,
 };

--- a/src/components/Nav/StyledNav.jsx
+++ b/src/components/Nav/StyledNav.jsx
@@ -12,6 +12,7 @@ const HeaderWrapp = styled.header`
   padding: 8px 16px;
   background-color: var(--main-text-color);
   border-bottom: 0.5px solid var(--border-color);
+  z-index: 10;
 `;
 
 const HeaderTitle = styled.span`

--- a/src/components/Nav/UploadNav.jsx
+++ b/src/components/Nav/UploadNav.jsx
@@ -5,9 +5,10 @@ import ArrowImg from '../../assets/images/icon-arrow-left.svg';
 const UploadNav = ({ btnName }) => {
   return (
     <>
-      <S.BtnWrapp>
+      <h1 className='hidden'>업로드 페이지</h1>
+      <button type='button'>
         <S.BackIcon src={ArrowImg} alt='뒤로가기버튼' />
-      </S.BtnWrapp>
+      </button>
       <Button name={btnName} size='ms' disabled='true' />
     </>
   );

--- a/src/components/common/TabMenu/StyledTabMenu.jsx
+++ b/src/components/common/TabMenu/StyledTabMenu.jsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 export const MenuWrapper = styled.ul`
+  position: sticky;
+  bottom: 0;
   display: flex;
-  flex-direction: row;
   justify-content: space-around;
   width: 100%;
   height: 60px;

--- a/src/pages/AddProduct/AddProduct.jsx
+++ b/src/pages/AddProduct/AddProduct.jsx
@@ -5,9 +5,9 @@ import LabelInput from '../../components/common/LabelInput/LabelInput';
 const AddProduct = () => {
   return (
     <S.AllWrapp>
+      <Nav type='upload' btnName='저장' />
       <S.MainWrapp>
         <h1 className='hidden'>상품등록 페이지</h1>
-        <Nav type='upload' btnName='저장' />
         <S.FormWrapp>
           <S.ProductAddText>이미지 등록</S.ProductAddText>
           <S.ProductLoadWrapp>

--- a/src/pages/AddProduct/AddProduct.jsx
+++ b/src/pages/AddProduct/AddProduct.jsx
@@ -4,35 +4,37 @@ import LabelInput from '../../components/common/LabelInput/LabelInput';
 
 const AddProduct = () => {
   return (
-    <S.LayOut>
-      <h1 className='hidden'>상품등록 페이지</h1>
-      <Nav type='upload' btnName='저장' />
-      <S.FormWrapp>
-        <S.ProductAddText>이미지 등록</S.ProductAddText>
-        <S.ProductLoadWrapp>
-          <S.ProductLabel htmlFor='이미지업로드' />
-          <input className='hidden' type='file' id='이미지업로드' />
-        </S.ProductLoadWrapp>
-        <LabelInput
-          type='text'
-          label='상품명'
-          forid='productName'
-          placeholder='2~15자 이내여야 합니다.'
-        />
-        <LabelInput
-          type='number'
-          label='가격'
-          forid='productprice'
-          placeholder='숫자만 입력 가능합니다.'
-        />
-        <LabelInput
-          type='text'
-          label='판매 링크'
-          forid='slaelink'
-          placeholder='URL을 입력해 주세요'
-        />
-      </S.FormWrapp>
-    </S.LayOut>
+    <S.AllWrapp>
+      <S.MainWrapp>
+        <h1 className='hidden'>상품등록 페이지</h1>
+        <Nav type='upload' btnName='저장' />
+        <S.FormWrapp>
+          <S.ProductAddText>이미지 등록</S.ProductAddText>
+          <S.ProductLoadWrapp>
+            <S.ProductLabel htmlFor='이미지업로드' />
+            <input className='hidden' type='file' id='이미지업로드' />
+          </S.ProductLoadWrapp>
+          <LabelInput
+            type='text'
+            label='상품명'
+            forid='productName'
+            placeholder='2~15자 이내여야 합니다.'
+          />
+          <LabelInput
+            type='number'
+            label='가격'
+            forid='productprice'
+            placeholder='숫자만 입력 가능합니다.'
+          />
+          <LabelInput
+            type='text'
+            label='판매 링크'
+            forid='slaelink'
+            placeholder='URL을 입력해 주세요'
+          />
+        </S.FormWrapp>
+      </S.MainWrapp>
+    </S.AllWrapp>
   );
 };
 

--- a/src/pages/AddProduct/StyledAddProduct.jsx
+++ b/src/pages/AddProduct/StyledAddProduct.jsx
@@ -1,14 +1,24 @@
 import styled from 'styled-components';
 import uploadBtnImg from '../../assets/images/img-button.svg';
+import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
+
 // 4~11 line 공용컴포넌트제작 필요성을 느낌
-export const LayOut = styled.section`
-  margin: 0 auto;
-  width: 390px;
-  height: 100vh;
+export const AllWrapp = styled.section`
+  ${AllWrappCss};
+`;
+export const MainWrapp = styled.section`
+  ${MainWrappCss};
+`;
+export const FormWrapp = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 30px;
+  div:nth-child(n + 2) {
+    width: 322px;
+  }
 `;
+
 export const ProductAddText = styled.span`
   font-size: 1.2rem;
   font-weight: 400;
@@ -16,17 +26,7 @@ export const ProductAddText = styled.span`
   color: #767676;
   margin-bottom: 18px;
   margin-right: auto;
-`;
-export const FormWrapp = styled.form`
-  display: flex;
-  flex-grow: 1;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 30px;
-  div:nth-child(n + 2) {
-    width: 322px;
-  }
-  /* Labelinput 컴포넌트 css 논의 필요 */
+  padding: 0 34px;
 `;
 
 export const ProductLoadWrapp = styled.div`

--- a/src/pages/AddProduct/StyledAddProduct.jsx
+++ b/src/pages/AddProduct/StyledAddProduct.jsx
@@ -24,8 +24,7 @@ export const ProductAddText = styled.span`
   font-weight: 400;
   line-height: 1.2rem;
   color: #767676;
-  margin-bottom: 18px;
-  margin-right: auto;
+  margin: 0 auto 18px 0;
   padding: 0 34px;
 `;
 

--- a/src/pages/ChatRoom/ChatRoom.jsx
+++ b/src/pages/ChatRoom/ChatRoom.jsx
@@ -1,5 +1,11 @@
+import Nav from '../../components/Nav/Nav';
+
 const ChatRoom = () => {
-  return <div>ChatRoom</div>;
+  return (
+    <>
+      <Nav type='follow' />;
+    </>
+  );
 };
 
 export default ChatRoom;

--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -10,7 +10,7 @@ const HomeFeed = () => {
   // 로직추가시 삼항연산자를 사용하여 메인1을 보여주거나, 메인2를 보여주기
   // 로직추가 후 스타일 일부 수정 필요
   return (
-    <>
+    <S.AllWrapp>
       <Nav type='main' />
       {/* // 메인1 */}
 
@@ -32,7 +32,7 @@ const HomeFeed = () => {
       </S.StyledHomeFeedOff>
 
       <TabMenu />
-    </>
+    </S.AllWrapp>
   );
 };
 

--- a/src/pages/HomeFeed/StyledHomeFeed.jsx
+++ b/src/pages/HomeFeed/StyledHomeFeed.jsx
@@ -1,24 +1,25 @@
 import styled from 'styled-components';
+import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
 
 export const StyledHomeFeedOn = styled.section`
-  /* width: 390px;
-  height: 712px; */
+  ${MainWrappCss};
   padding: 20px 16px 30px;
   display: flex;
   flex-direction: column;
   gap: 24px;
   margin: 0 auto;
+  background-color: var(--main-text-color);
 `;
 
 export const StyledHomeFeedOff = styled.section`
-  /* width: 390px;
-  height: 712px; */
+  ${MainWrappCss};
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 390px;
   margin: 0 auto;
-
+  background-color: var(--main-text-color);
+  //body backgroundcolor 구분하려고 넣었습니다.
   img {
     width: 150px;
     margin-bottom: 25px;
@@ -30,4 +31,13 @@ export const StyledHomeFeedOff = styled.section`
     color: #767676;
     margin-bottom: 20px;
   }
+`;
+
+// 추가해야할 스타일 컴포넌트
+export const AllWrapp = styled.section`
+  ${AllWrappCss};
+`;
+
+export const MainContWrapp = styled.section`
+  ${MainWrappCss};
 `;

--- a/src/pages/HomeFeed/StyledHomeFeed.jsx
+++ b/src/pages/HomeFeed/StyledHomeFeed.jsx
@@ -3,10 +3,10 @@ import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
 
 export const StyledHomeFeedOn = styled.section`
   ${MainWrappCss};
-  padding: 20px 16px 30px;
   display: flex;
   flex-direction: column;
   gap: 24px;
+  padding: 20px 16px 30px;
   margin: 0 auto;
   background-color: var(--main-text-color);
 `;

--- a/src/pages/JoinEmail/StyledJoinEmail.jsx
+++ b/src/pages/JoinEmail/StyledJoinEmail.jsx
@@ -1,10 +1,11 @@
 import styled from 'styled-components';
 import Button from '../../components/common/Button/Button';
+import { AllWrappCss } from '../../styles/Globalstyled';
 
 export const JoinEmailWrapper = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  ${AllWrappCss};
+  background-color: #fff;
+  /* 임시 */
 `;
 
 export const JoinEmailTitle = styled.h1`

--- a/src/pages/JoinProfileEdit/StyledJoinProfileEdit.jsx
+++ b/src/pages/JoinProfileEdit/StyledJoinProfileEdit.jsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import Button from '../../components/common/Button/Button';
+import { AllWrappCss } from '../../styles/Globalstyled';
 
 export const JoinPfWrap = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  ${AllWrappCss};
+  background-color: #fff; /* 임시적용 삭제예정 */
 `;
 
 export const JoinPfTitle = styled.h1`

--- a/src/pages/LoginEmail/LoginEmail.jsx
+++ b/src/pages/LoginEmail/LoginEmail.jsx
@@ -54,30 +54,32 @@ const LoginEmail = () => {
 
   return (
     <S.LoginWrapper>
-      <S.LoginTitle>로그인</S.LoginTitle>
-      <form onSubmit={handleSubmit}>
-        <LabelInput
-          label='이메일'
-          forid='email'
-          type='email'
-          state={email}
-          onChange={handleData}
-          onKeyUp={handleCheckValid}
-        />
-        <LabelInput
-          label='비밀번호'
-          forid='password'
-          type='password'
-          state={password}
-          onChange={handleData}
-          onKeyUp={handleCheckValid}
-        />
-        <div>{message}</div>
-        <S.LoginBtn name='로그인' disabled={!isValid} />
-        {/* disabled 가 true 일때 버튼이 비활성화 , false 일때 활성화  defalut는 false */}
-        {/* 유효성 검사에서 true를 반환, disalbed에서 (!유효성검사결과) 활성화 === false */}
-      </form>
-      <S.LoginLink to='/joinemail'>이메일로 회원가입</S.LoginLink>
+      <S.MainWrapper>
+        <S.LoginTitle>로그인</S.LoginTitle>
+        <form onSubmit={handleSubmit}>
+          <LabelInput
+            label='이메일'
+            forid='email'
+            type='email'
+            state={email}
+            onChange={handleData}
+            onKeyUp={handleCheckValid}
+          />
+          <LabelInput
+            label='비밀번호'
+            forid='password'
+            type='password'
+            state={password}
+            onChange={handleData}
+            onKeyUp={handleCheckValid}
+          />
+          <div>{message}</div>
+          <S.LoginBtn name='로그인' disabled={!isValid} />
+          {/* disabled 가 true 일때 버튼이 비활성화 , false 일때 활성화  defalut는 false */}
+          {/* 유효성 검사에서 true를 반환, disalbed에서 (!유효성검사결과) 활성화 === false */}
+        </form>
+        <S.LoginLink to='/joinemail'>이메일로 회원가입</S.LoginLink>
+      </S.MainWrapper>
     </S.LoginWrapper>
   );
 };

--- a/src/pages/LoginEmail/StyledLoginEmail.jsx
+++ b/src/pages/LoginEmail/StyledLoginEmail.jsx
@@ -1,8 +1,13 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '../../components/common/Button/Button';
+import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
 
 export const LoginWrapper = styled.section`
+  ${AllWrappCss};
+`;
+export const MainWrapper = styled.section`
+  ${MainWrappCss};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/pages/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/ModifyProfile/ModifyProfile.jsx
@@ -5,7 +5,7 @@ import LabelInput from '../../components/common/LabelInput/LabelInput';
 
 const ModifyProfile = () => {
   return (
-    <S.LayOut>
+    <S.AllWrapp>
       <h1 className='hidden'>프로필 수정 페이지</h1>
       <Nav type='upload' btnName='저장' />
       <S.FormWrapp>
@@ -33,7 +33,7 @@ const ModifyProfile = () => {
           placeholder='자신과 판매할 상품에 대해 소개해주세요.'
         />
       </S.FormWrapp>
-    </S.LayOut>
+    </S.AllWrapp>
   );
 };
 

--- a/src/pages/ModifyProfile/StyledModifyProfile.jsx
+++ b/src/pages/ModifyProfile/StyledModifyProfile.jsx
@@ -1,21 +1,17 @@
 import styled from 'styled-components';
 import modifyProfileImg from '../../assets/images/upload-file.svg';
+import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
 // 4~11 line 공용컴포넌트제작 필요성을 느낌
-export const LayOut = styled.section`
-  margin: 0 auto;
-  width: 390px;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+
+export const AllWrapp = styled.section`
+  ${AllWrappCss};
 `;
 
 export const FormWrapp = styled.form`
+  ${MainWrappCss};
   display: flex;
-  flex-grow: 1;
   flex-direction: column;
   align-items: center;
-  margin-top: 30px;
   div:nth-child(n + 2) {
     width: 322px;
   }
@@ -26,7 +22,7 @@ export const ProfileImgWrapp = styled.div`
   position: relative;
   width: 110px;
   height: 110px;
-  margin-bottom: 29px;
+  margin: 30px 0;
   label {
     position: absolute;
     width: 32px;

--- a/src/styles/Globalstyled.jsx
+++ b/src/styles/Globalstyled.jsx
@@ -8,6 +8,7 @@ const GlobalStyled = createGlobalStyle`
     --main-disabled-color:#c8beab;
     --main-text-color:#ffffff;
     --sub-text-color:#767676;
+    --border-color:#bdbdbd;
   }
   html {
     font-size: 10px;

--- a/src/styles/Globalstyled.jsx
+++ b/src/styles/Globalstyled.jsx
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
 import reset from 'styled-reset';
 
 const GlobalStyled = createGlobalStyle`
@@ -17,6 +17,8 @@ const GlobalStyled = createGlobalStyle`
   body {
     font-family: "Spoqa Han Sans Neo", sans-serif;
     font-weight: 400;
+    background-color: #e8e8e8;
+    /* 배경과 구분하려고 색 넣었습니다. */
   }
 
   * {
@@ -41,6 +43,21 @@ const GlobalStyled = createGlobalStyle`
     height: 1px;
     overflow: hidden;
   }
+`;
+
+// 전체를 감싸는 컨테이너 박스에 들어가야 하는 공통 css
+export const AllWrappCss = css`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+// main contents에 들어가야 하는 공통 css
+export const MainWrappCss = css`
+  min-width: 390px;
+  flex-grow: 1;
+  background-color: #fff; // 삭제될 수 있음.
 `;
 
 export default GlobalStyled;


### PR DESCRIPTION
# page UI & Layout 및 common component 수정

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- FilChange tap 참고

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 페이지를 총 3구간으로 나눠 스타일을 적용시킨다고 생각하시면 됩니다.
 최상위: 전체를 감싸는 `<Section Container>`
 하위 : `<header>, <Main>, <footer>` (footer 는 TapMenu 입니다)
 
- GlobalStyle에 작성한, [AllWrappCss], [MainWrappCss]을 import 하여, 각 페이지의 전체 섹션, 메인섹션에 스타일을 적용시켜주시기 바랍니다~!
 

## [📢 Notice]

- Nav Component를 Header 로 이름변경하였습니다.
- Header components의 스타일을 수정하였습니다.(position 값 등)
- TabMenu components의 스타일을 수정하였습니다.(position 값 등)
- 공통으로 적용되는 CSS를 컴포넌트화 하여, 페이지마다 일관성있는 코드가 될 수 있도록 변경하였습니다.
- 사진

**GlobalStyled 에 추가된 공통 CSS 컴포넌트**
<img width="551" alt="image" src="https://user-images.githubusercontent.com/89332492/209104250-ad6f0df3-2eeb-442f-be11-f9d7f860d881.png">

**공통 CSS 적용 예시 (Modifyprofile page)**
<img width="460" alt="스크린샷 2022-12-22 오후 6 39 22" src="https://user-images.githubusercontent.com/89332492/209105786-4d06257b-9f6a-4b9b-896a-84292203dfe1.png">

- 위 예시처럼 전체를 감싸는 container와  태그가 없을 경우 생성하여 AllWrappCss 를 적용시켜주세요
- MainWrappCss 는 별도의 Container 태그를 생성하지 않고, 메인컨텐츠 격의 태그에 공통CSS만 적용시켜도 좋습니다.
   (필요에 따라 생성이 필요하면 생성하여 적용시켜주세요.)
