### PR TITLE
<feat> : 상품데이터 서버 전송

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -124,6 +124,19 @@ const FetchApi = {
     const data = await response.json();
     return data;
   },
+  async registerProduct(reqData, token) {
+    const response = await fetch(`${BASE_URL}/product`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(reqData),
+    });
+    const data = await response.json();
+    console.log(data);
+    return data;
+  },
 };
 
 export default FetchApi;

--- a/src/pages/AddProduct/AddProduct.jsx
+++ b/src/pages/AddProduct/AddProduct.jsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/context';
 import Nav from '../../components/Nav/Nav';
 import LabelInput from '../../components/common/LabelInput/LabelInput';
 import FetchApi from '../../api';
@@ -10,6 +12,9 @@ const AddProduct = () => {
   const [productName, setProductName] = useState('');
   const [productPrice, setProductPrice] = useState('');
   const [saleLink, setSaleLink] = useState('');
+
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
 
   // 모든 값 valid check, 서버 전송 가능 상태시 버튼 true
   const [isValid, setIsValid] = useState({
@@ -55,6 +60,7 @@ const AddProduct = () => {
   const handleGetImg = async (event) => {
     const data = await FetchApi.uploadImg(event);
     setproductImg(data);
+    console.log(productImg);
     setIsValid({ ...isValid, productImg: true });
   };
 
@@ -92,12 +98,27 @@ const AddProduct = () => {
     }
   };
 
+  const handleSubmit = async (event) => {
+    event.preventDefault(); // submit 제출 막기(새로고침막기)
+    const reqData = {
+      product: {
+        itemName: `${productName}`,
+        price: parseInt(productPrice.replace(',', ''), 10), // 서버 전송 가능 형태로 가공
+        link: `${saleLink}`,
+        itemImage: `${productImg}`,
+      },
+    };
+    const productData = await FetchApi.registerProduct(reqData, user.token);
+    console.log(productData);
+    navigate('/myprofile');
+  };
+
   return (
-    <S.AllWrapp>
+    <S.AllWrapp onSubmit={handleSubmit}>
       <Nav type='upload' btnName='저장' disabled={!pass} />
       <S.MainWrapp>
         <h1 className='hidden'>상품등록 페이지</h1>
-        <S.FormWrapp>
+        <S.InputWrapp>
           <S.ProductAddText>이미지 등록</S.ProductAddText>
           <S.ProductLoadWrapp>
             <S.ProductLabel htmlFor='이미지업로드' />
@@ -136,7 +157,7 @@ const AddProduct = () => {
             onChange={handleData}
             onBlur={handleCheckSaleLink}
           />
-        </S.FormWrapp>
+        </S.InputWrapp>
       </S.MainWrapp>
     </S.AllWrapp>
   );

--- a/src/pages/AddProduct/StyledAddProduct.jsx
+++ b/src/pages/AddProduct/StyledAddProduct.jsx
@@ -3,13 +3,13 @@ import uploadBtnImg from '../../assets/images/img-button.svg';
 import { AllWrappCss, MainWrappCss } from '../../styles/Globalstyled';
 
 // 4~11 line 공용컴포넌트제작 필요성을 느낌
-export const AllWrapp = styled.section`
+export const AllWrapp = styled.form`
   ${AllWrappCss};
 `;
 export const MainWrapp = styled.section`
   ${MainWrappCss};
 `;
-export const FormWrapp = styled.form`
+export const InputWrapp = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
# <feat> : 상품데이터 서버 전송

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/api/index.js
- src/pages/AddProduct/AddProduct.jsx
- src/pages/AddProduct/StyledAddProduct.jsx

## [📝 생성된 파일]

- 없음
- 
## [📌 제안 사항]

- 없음

## [📢 Notice]

- 상품 이미지,가격,url 주소를 입력해서 저장 버튼을 클릭하면 서버에 전송되는 기능 구현
- 아래는 레고마켓 서버 전송 테스트 사진
(아직 myprofile 에서 상품 리스트 불러오기 기능 구현을 하지 못해서 레고마켓에 상품이 업로드된 사진으로 인증 대체합니다. 
![image](https://user-images.githubusercontent.com/107895498/209559510-4c3ef151-3050-4034-81fb-944bf60f2686.png)

- API 폴더의 index.js 에서 서버전송 성공한 콘솔창 인증사진 
![image](https://user-images.githubusercontent.com/107895498/209560538-b6a76746-c43a-4e5a-b45b-e1e72acde8c2.png)

