### PR TITLE
<Refact> : 홈피드 리팩토링

### DIFF
--- a/src/components/common/PostCard/PostCard.jsx
+++ b/src/components/common/PostCard/PostCard.jsx
@@ -1,4 +1,5 @@
 import { useContext, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../../context/context';
 import HeartIcon from '../../../assets/images/icon-heart.svg';
 import MessageCircleIcon from '../../../assets/images/icon-message-circle-mini.svg';
@@ -8,10 +9,22 @@ import OthersPostModal from '../Modal/OthersPostModal';
 import PostInnerModal from '../Modal/PostInnerModal';
 import * as S from './StyledPostCard';
 
-const PostCard = ({ userdata, content, image, date, postId }) => {
+const PostCard = ({ data }) => {
+  const {
+    author,
+    content,
+    image,
+    createdAt,
+    id,
+    heartCount,
+    hearted,
+    commentCount,
+  } = data;
   const { user } = useContext(AuthContext);
   const [isShowModal, setIsShowModal] = useState(false);
   const [isShowInnerModal, setIsShowInnerModal] = useState(false);
+  const navigate = useNavigate();
+  console.log(hearted);
 
   const handleShowModal = () => {
     setIsShowModal(true);
@@ -30,37 +43,58 @@ const PostCard = ({ userdata, content, image, date, postId }) => {
     setIsShowModal(false);
   };
 
+  const handleGoUserPage = () => {
+    navigate(`/yourprofile/${author.accountname}`);
+  };
+
+  const handleGoDetailPage = () => {
+    navigate(`/postdetail/${id}`);
+  };
+
   return (
     <>
       <S.ContentsWrapper>
-        <S.ProfileImage src={userdata.image} alt='프로필 이미지' />
+        <S.ProfileImage
+          src={author.image}
+          alt='프로필 이미지'
+          onClick={handleGoUserPage}
+        />
+
         <S.UserInfo>
-          <S.UserName>{userdata.username}</S.UserName>
-          <S.UserAccount>@ {userdata.accountname}</S.UserAccount>
+          <Link to={`/yourprofile/${author.accountname}`}>
+            <S.UserName>{author.username}</S.UserName>
+            <S.UserAccount>@ {author.accountname}</S.UserAccount>
+          </Link>
           <button type='button' onClick={handleShowModal}>
             <img src={verticalMenuIcon} alt='더보기 메뉴' />
           </button>
         </S.UserInfo>
 
-        <S.PostContents>
+        <S.PostContents onClick={handleGoDetailPage}>
           <p>{content}</p>
-          {image && <img src={image} alt='감귤농장 이미지' />}
+          {image && <img src={image} alt='컨텐츠 관련 이미지' />}
         </S.PostContents>
 
         <S.BtnWrapper>
           <button type='button'>
-            <img src={HeartIcon} alt='좋아요 버튼' /> <span>58</span>
+            <img src={HeartIcon} alt='좋아요 버튼' />
+            <span>{heartCount}</span>
           </button>
-          <button type='button'>
-            <img src={MessageCircleIcon} alt='' /> <span>12</span>
+          <button type='button' onClick={handleGoDetailPage}>
+            <img src={MessageCircleIcon} alt='댓글 버튼' />
+            <span>{commentCount}</span>
           </button>
         </S.BtnWrapper>
         <S.PostDate>
-          {`${date.slice(0, 10).replace('-', '년 ').replace('-', '월 ')}일`}
+          {`${createdAt
+            .slice(0, 10)
+            .replace('-', '년 ')
+            .replace('-', '월 ')}일`}
         </S.PostDate>
       </S.ContentsWrapper>
+
       {/* eslint-disable-next-line no-nested-ternary */}
-      {!isShowModal ? null : userdata.accountname === user.accountname ? (
+      {!isShowModal ? null : author.accountname === user.accountname ? (
         <MyPostModal
           CloseModal={handleCloseModal}
           ShowInnerModal={hanldeShowInnerModal}
@@ -72,17 +106,17 @@ const PostCard = ({ userdata, content, image, date, postId }) => {
         />
       )}
       {/* eslint-disable-next-line no-nested-ternary */}
-      {!isShowInnerModal ? null : userdata.accountname === user.accountname ? (
+      {!isShowInnerModal ? null : author.accountname === user.accountname ? (
         <PostInnerModal
           name='삭제'
           CloseInnerModal={handlCloseInnerModal}
-          postId={postId}
+          postId={id}
         />
       ) : (
         <PostInnerModal
           name='신고'
           CloseInnerModal={handlCloseInnerModal}
-          postId={postId}
+          postId={id}
         />
       )}
     </>

--- a/src/components/common/PostCard/StyledPostCard.jsx
+++ b/src/components/common/PostCard/StyledPostCard.jsx
@@ -16,6 +16,7 @@ export const ProfileImage = styled.img`
   position: absolute;
   top: 0;
   left: 0;
+  cursor: pointer;
 `;
 
 export const ProfileWrapper = styled.div`
@@ -26,21 +27,23 @@ export const ProfileWrapper = styled.div`
 export const UserInfo = styled.div`
   position: relative;
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-
-  img {
+  justify-content: space-between;
+  /* button {
     position: absolute;
     width: 18px;
     top: 0;
     right: 0;
-  }
+    img {
+      width: 100%;
+    }
+  } */
 `;
 
 export const UserName = styled.h2`
   font-weight: 500;
   font-size: 1.4rem;
   line-height: 18px;
+  color: #000;
 `;
 
 export const UserAccount = styled.p`
@@ -53,6 +56,11 @@ export const PostContents = styled.div`
   font-size: 1.4rem;
   line-height: 1.8rem;
   /* gap: 16px; */
+  cursor: pointer;
+
+  p {
+    color: #000000;
+  }
 
   img {
     width: 304px;

--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -36,14 +36,7 @@ const HomeFeed = () => {
         <S.StyledHomeFeedOn>
           <h2 className='hidden'>피드 리스트</h2>
           {feed.map((item) => (
-            <PostCard
-              key={item.id}
-              userdata={item.author}
-              content={item.content}
-              image={item.image}
-              date={item.createdAt}
-              postId={item.id}
-            />
+            <PostCard key={item.id} data={item} />
           ))}
         </S.StyledHomeFeedOn>
       ) : (


### PR DESCRIPTION
# <Refact> : 홈피드 리팩토링

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/components/common/PostCard/PostCard.jsx
- src/components/common/PostCard/StyledPostCard.jsx
- src/pages/HomeFeed/HomeFeed.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 사용자 프로필이나 계정, 컨텐츠, 댓글을 클릭했을 시 링크 연결
- 하트, 댓글 수를 api로 받아온 값으로 변경
- HomeFeed에서 PostCard로 전해주는 props 내용 변경. 기존에는 구조분해할당으로 일일이 내려주었는데 내려줄 것이 많아져서 data 하나로 전달한 후 PostCard 컴포넌트 내에서 구조분해할당 하는식으로 변경하였습니다.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/96678570/209775430-2fa9a1da-9465-49a3-8ac5-ca65db120773.png">
<img width="250" alt="image" src="https://user-images.githubusercontent.com/96678570/209775461-6b0e029c-b175-47c7-8708-3770c90a073b.png">


