### PR TITLE
<feat> : 상품리스트 메인+이너 모달 추가

### DIFF
--- a/src/components/common/Modal/Modal.jsx
+++ b/src/components/common/Modal/Modal.jsx
@@ -1,14 +1,22 @@
 import * as S from './StyledModal';
 
-const Modal = () => {
+const Modal = ({ handleCloseModal, handleShowInnerModal }) => {
   return (
-    <S.ModalWrapper>
+    <S.ModalWrapper onClick={handleCloseModal}>
       <S.ModalContainer>
         <S.ModalBar />
         <ul>
-          <S.ModalList>삭제</S.ModalList>
-          <S.ModalList>수정</S.ModalList>
-          <S.ModalList>웹사이트에서 상품 보기</S.ModalList>
+          <S.ModalList>
+            <button type='button' onClick={handleShowInnerModal}>
+              삭제
+            </button>
+          </S.ModalList>
+          <S.ModalList>
+            <button type='button'>수정</button>
+          </S.ModalList>
+          <S.ModalList>
+            <button type='button'>웹사이트에서 상품 보기</button>
+          </S.ModalList>
         </ul>
       </S.ModalContainer>
     </S.ModalWrapper>

--- a/src/components/common/Modal/ProductInnerModal.jsx
+++ b/src/components/common/Modal/ProductInnerModal.jsx
@@ -1,0 +1,24 @@
+import {
+  InnerModalContainer,
+  InnerModalWrap,
+  InnerModalBtnWrap,
+} from './StyledPostInnerModal';
+
+const ProductInnerModal = ({ handleCloseInnerModal }) => {
+  return (
+    <InnerModalContainer>
+      <h2 className='hidden'>상품 삭제 모달</h2>
+      <InnerModalWrap>
+        <p>상품을 삭제할까요?</p>
+        <InnerModalBtnWrap>
+          <button type='button' onClick={handleCloseInnerModal}>
+            취소
+          </button>
+          <button type='button'>삭제</button>
+        </InnerModalBtnWrap>
+      </InnerModalWrap>
+    </InnerModalContainer>
+  );
+};
+
+export default ProductInnerModal;

--- a/src/components/common/Modal/StyledModal.jsx
+++ b/src/components/common/Modal/StyledModal.jsx
@@ -3,10 +3,14 @@ import styled from 'styled-components';
 export const ModalWrapper = styled.div`
   position: absolute;
   top: 0;
+  bottom: 0;
   left: 0;
+  right: 0;
+  z-index: 20;
+  margin: 0 auto;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.2);
 `;
 
 export const ModalContainer = styled.div`
@@ -33,4 +37,11 @@ export const ModalList = styled.li`
   padding: 14px 26px;
   font-size: 1.4rem;
   line-height: 1.8rem;
+
+  & > button {
+    cursor: pointer;
+    display: block;
+    text-align: left;
+    width: 100%;
+  }
 `;

--- a/src/components/common/Product/Product.jsx
+++ b/src/components/common/Product/Product.jsx
@@ -6,13 +6,11 @@ const Product = ({ product }) => {
     .toString()
     .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
   return (
-    <S.wrapper>
-      <button type='button'>
-        <S.ProductImg src={product.itemImage} alt='업로드된상품이미지' />
-        <S.ProductName>{product.itemName}</S.ProductName>
-        <S.ProductPrice>{replacePrice}원</S.ProductPrice>
-      </button>
-    </S.wrapper>
+    <>
+      <S.ProductImg src={product.itemImage} alt='업로드된상품이미지' />
+      <S.ProductName>{product.itemName}</S.ProductName>
+      <S.ProductPrice>{replacePrice}원</S.ProductPrice>
+    </>
   );
 };
 

--- a/src/components/common/Product/ProductWrapp.jsx
+++ b/src/components/common/Product/ProductWrapp.jsx
@@ -3,10 +3,15 @@ import { AuthContext } from '../../../context/context';
 import FetchApi from '../../../api';
 import ProductSection from './StyledProductWrapp';
 import Product from './Product';
+import Modal from '../Modal/Modal';
+import ProductInnerModal from '../Modal/ProductInnerModal';
 
 const ProductWrapp = () => {
   const [productList, setProductList] = useState([]);
   const { user } = useContext(AuthContext);
+  // 모달 열기
+  const [openModal, setOpenModal] = useState(false);
+  const [openInnerModal, setOpenInnerModal] = useState(false);
 
   // 화면에 첫 렌더링될때만 서버통신 실행
   useEffect(() => {
@@ -18,16 +23,58 @@ const ProductWrapp = () => {
     setProductFeed();
   }, []);
 
-  return productList.length > 0 ? (
-    <ProductSection>
-      <h2>판매 중인 상품</h2>
-      <div>
-        {productList.map((item) => {
-          return <Product key={item.id} product={item} />;
-        })}
-      </div>
-    </ProductSection>
-  ) : null;
+  // 메인 모달 열기 함수
+  const handleShowModal = () => {
+    setOpenModal(true);
+  };
+
+  // 메인 모달 닫기 함수
+  const handleCloseModal = (event) => {
+    // 부모요소인 S.ModalWrapper 를 클릭했을때만 이벤트가 실행되게 하기
+    if (event.target === event.currentTarget) {
+      setOpenModal(false);
+    }
+  };
+
+  // 이너 모달 열기 함수
+  const handleShowInnerModal = () => {
+    setOpenInnerModal(true);
+  };
+  // 이너 모달 닫기 함수
+  const handleCloseInnerModal = () => {
+    setOpenModal(false);
+    setOpenInnerModal(false);
+  };
+
+  return (
+    <>
+      {productList.length > 0 ? (
+        <ProductSection>
+          <h2>판매 중인 상품</h2>
+          <ul>
+            <li>
+              {productList.map((item) => {
+                return (
+                  <button key={item.id} type='button' onClick={handleShowModal}>
+                    <Product product={item} />
+                  </button>
+                );
+              })}
+            </li>
+          </ul>
+        </ProductSection>
+      ) : null}
+      {openModal && (
+        <Modal
+          handleCloseModal={handleCloseModal}
+          handleShowInnerModal={handleShowInnerModal}
+        />
+      )}
+      {openInnerModal && (
+        <ProductInnerModal handleCloseInnerModal={handleCloseInnerModal} />
+      )}
+    </>
+  );
 };
 
 export default ProductWrapp;

--- a/src/components/common/Product/StyledProduct.jsx
+++ b/src/components/common/Product/StyledProduct.jsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
 
-export const wrapper = styled.figure`
-  width: 140px;
-  & > button {
-    cursor: pointer;
-    text-align: left;
-  }
-`;
+// export const wrapper = styled.figure`
+//   width: 140px;
+//   & > button {
+//     cursor: pointer;
+//     text-align: left;
+//   }
+// `;
 
 export const ProductImg = styled.img`
   width: 140px;
@@ -15,12 +15,12 @@ export const ProductImg = styled.img`
   object-fit: cover;
 `;
 
-export const ProductName = styled.figcaption`
+export const ProductName = styled.p`
   margin: 6px 2px 4px 2px;
   font-size: 1.4rem;
 `;
 
-export const ProductPrice = styled.figcaption`
+export const ProductPrice = styled.p`
   margin: 0 0 0 2px;
   font-size: 1.2rem;
   font-weight: 700;

--- a/src/components/common/Product/StyledProductWrapp.jsx
+++ b/src/components/common/Product/StyledProductWrapp.jsx
@@ -13,7 +13,7 @@ const ProductSection = styled.section`
     line-height: 2rem;
     font-weight: 700;
   }
-  div {
+  li {
     display: flex;
     gap: 10px;
   }

--- a/src/pages/AddProduct/StyledAddProduct.jsx
+++ b/src/pages/AddProduct/StyledAddProduct.jsx
@@ -54,7 +54,7 @@ export const ProductLabel = styled.label`
   border-radius: 50%;
   bottom: 12px;
   right: 12px;
-  z-index: 20;
+  z-index: 10;
   cursor: pointer;
   background: no-repeat center/32px url(${uploadBtnImg});
 `;


### PR DESCRIPTION
# <feat> : 상품리스트 메인+이너 모달 추가

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/components/common/Modal/Modal.jsx
- src/components/common/Modal/StyledModal.jsx
- src/components/common/Product/Product.jsx
- src/components/common/Product/ProductWrapp.jsx
- src/components/common/Product/StyledProductWrapp.jsx

## [📝 생성된 파일]

- src/components/common/Modal/ProductInnerModal.jsx

## [📌 제안 사항]

- 기억하고 싶은 이슈사항
1) button 태그 안에는 figure,figcaption 태그를 쓸 수 없다. (validation 이슈)
![image](https://user-images.githubusercontent.com/107895498/209789124-da282343-8603-4451-8741-14911658d58c.png)

2) 부모 태그 안 자식 태그가 여럿 있을 때 event 전파 막는 방법
- 모달창의 부모 영역을 클릭했을 때만 모달창을 닫게 하고싶었지만, 자식 태그까지 이벤트가 전파되어
자식 영역을 클릭해도 모달창이 닫히는 이슈 발생
- 해결방법 : 많이들 사용하는 e.stopPropagtion 을 활용하여, 자식 엘리먼트에서 전파를 막아도 되지만, 부모 엘리먼트 단에서 if (e.target !== e.currentTarget) return; 과 같은 코드로 막을 수 있으면, 각각의 자식요소들에서 e.stopPropagtion 로 처리를 해줄 필요가 없어, 자식요소들에서 중복된 여러 코드들을 사용하지 않아도 된다.

![image](https://user-images.githubusercontent.com/107895498/209789729-ba239725-4115-45bc-8f26-5f78e8c3d457.png)


## [📢 Notice]

- 모달창을 스무스하게 보여주는 애니메이션은 추후 기능 추가할 예정입니다.
- 아직 myprofile 페이지 미완성으로 addproduct 페이지에서 렌더링 테스트 하였습니다. 
- ProductWrapp 컴포넌트를 MyProfile로 옮길 시 모달창 크기 이슈는 사라집니다.(모달창 전체화면으로 꽉채워짐)
![모달구현](https://user-images.githubusercontent.com/107895498/209790243-cfcbe709-ca18-4774-9b7b-1c0859f6f40d.gif)

