### PR TITLE
<Refact> : 홈피드 가운데 정렬 리팩토링

### DIFF
--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -44,14 +44,16 @@ const HomeFeed = () => {
         </S.StyledHomeFeedOn>
       ) : (
         <S.StyledHomeFeedOff>
-          <img src={symbolLogoMini} alt='심볼로고' />
-          <p>유저를 검색해 팔로우 해보세요!</p>
-          <Button
-            name='검색하기'
-            type='button'
-            size='m'
-            onClick={handleGoSearch}
-          />
+          <div>
+            <img src={symbolLogoMini} alt='심볼로고' />
+            <p>유저를 검색해 팔로우 해보세요!</p>
+            <Button
+              name='검색하기'
+              type='button'
+              size='m'
+              onClick={handleGoSearch}
+            />
+          </div>
         </S.StyledHomeFeedOff>
       )}
       <TabMenu />

--- a/src/pages/HomeFeed/StyledHomeFeed.jsx
+++ b/src/pages/HomeFeed/StyledHomeFeed.jsx
@@ -14,20 +14,26 @@ export const StyledHomeFeedOn = styled.section`
 export const StyledHomeFeedOff = styled.section`
   ${MainWrappCss};
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
   width: 390px;
   margin: 0 auto;
   background-color: var(--main-text-color);
-  //body backgroundcolor 구분하려고 넣었습니다.
+
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
   img {
     width: 150px;
-    margin: 260px 0 25px 0;
+    margin-bottom: 25px;
   }
+
   p {
     font-size: 1.4rem;
     line-height: 1.4rem;
-    text-align: center;
     color: #767676;
     margin-bottom: 20px;
   }


### PR DESCRIPTION
# <Refact> : 홈피드 가운데 정렬 리팩토링

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/pages/HomeFeed/HomeFeed.jsx
- src/pages/HomeFeed/StyledHomeFeed.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]
-  홈피드에서 팔로잉한 유저가 없을 때 나타나는 유저 검색하기 내용 가운데 정렬 리팩토링
- 이전에는 이미지에 margin-top을 적용하여 가운데 정렬을 했는데 아래와 같이 창의 높이에 따라 가운데 정렬이 되지 않는 문제가 발생함.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/96678570/210202395-cc81d7ac-eae0-45ee-8ade-a79425fd030c.png">

- flex를 이용하여 창의 높이에 관계 없이 유동적으로 가운데 정렬이 될 수 있도록 수정. 
<img width="490" alt="image" src="https://user-images.githubusercontent.com/96678570/210202497-c89835a2-21bb-484d-96be-06d48a039dab.png">

<img width="449" alt="image" src="https://user-images.githubusercontent.com/96678570/210202351-5e3d9e80-badf-4507-88f6-50aa8c5f56fc.png">
