### PR TITLE
<refact> : UserProfile_PostCardAlbumtype 이미지 받아오기 수정

### DIFF
--- a/src/components/common/PostAlbum/PostAlbum.jsx
+++ b/src/components/common/PostAlbum/PostAlbum.jsx
@@ -1,14 +1,5 @@
 const PostAlbum = ({ data }) => {
-  const {
-    // author,
-    // content,
-    image,
-    // createdAt,
-    // id,
-    // heartCount,
-    // hearted,
-    // commentCount,
-  } = data;
+  const { image } = data;
   return (
     <li>
       <img src={image} alt='사진입니다.' />

--- a/src/pages/Profile/UserProfile/StyledUserProfile.jsx
+++ b/src/pages/Profile/UserProfile/StyledUserProfile.jsx
@@ -27,6 +27,7 @@ export const PostCardWrap = styled.div`
 
 export const ProfilePostAlbumWrap = styled.ul`
   max-width: 390px;
+  min-height: 100vh;
   padding: 16px;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;

--- a/src/pages/Profile/UserProfile/UserProfile.jsx
+++ b/src/pages/Profile/UserProfile/UserProfile.jsx
@@ -17,6 +17,7 @@ const UserProfile = () => {
   const authAccountName = user.accountname;
   const [userProfile, setUserProfile] = useState(null);
   const [userPostArr, setUserPostArr] = useState([]);
+  const [userAlbumPostArr, setUserAlbumPostArr] = useState([]);
   const [list, setList] = useState(true);
   const location = useLocation();
   const pageAccount = location.pathname.split('/')[2];
@@ -45,6 +46,8 @@ const UserProfile = () => {
         });
         const data = await response.json();
         setUserPostArr(data.post);
+        const newdata = data.post.filter((post) => post.image !== '');
+        setUserAlbumPostArr(newdata);
       };
       getMyPost();
     }
@@ -78,7 +81,7 @@ const UserProfile = () => {
             </S.PostCardWrap>
           ) : (
             <S.ProfilePostAlbumWrap>
-              {userPostArr.map((item, index) => (
+              {userAlbumPostArr.map((item, index) => (
                 <PostAlbum key={item.id} data={item} index={index} />
               ))}
             </S.ProfilePostAlbumWrap>


### PR DESCRIPTION
# UserProfile_PostCardAlbumtype 이미지 받아오기 수정

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/pages/Profile/UserProfile/UserProfile.jsx
- src/pages/Profile/UserProfile/StyledUserProfile.jsx
- src/components/common/PostAlbum/PostAlbum.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- UserProfile PostCard Album type 경우 이미지가 없는 게시물은 제외하고 나타내도록 하였음.
- Post data를 받아올때, image key 값이 빈배열인 인자는 필터 후, 빈배열에 담아 새로운 배열을 생성하여 data로 활용하였음.
- close #162
