### PR TITLE
<refact> : 탭메뉴 기능 수정

### DIFF
--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -62,7 +62,10 @@ const TabMenu = () => {
         <S.MenuNavLink to={`/profile/${authAccountName}`}>
           <S.MenuImg
             src={
-              location.pathname === `/profile/${authAccountName}`
+              location.pathname === `/profile/${authAccountName}` ||
+              location.pathname ===
+                `/profile/${authAccountName}/followinglist` ||
+              location.pathname === `/profile/${authAccountName}/followerlist`
                 ? activeIconUser
                 : iconUser
             }


### PR DESCRIPTION
- Close #172

# <refact> : 탭메뉴 기능 수정

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/components/common/TabMenu/TabMenu.jsx

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 이슈사항
아래와 같이 반복되는 걸 변수로 선언하면 어떤 페이지를 가도 true 값이 나와서 버튼 이미지가 활성화됨 
자세한 설명은 캡처본 참고
const PROFILE_TAB = location.pathname === `/profile/${authAccountName}`;
<S.MenuImg
            src={
              `${PROFILE_TAB}` ||
              `${PROFILE_TAB}/
                followinglist` ||
              `${PROFILE_TAB}/followerlist`
                ? activeIconUser
                : iconUser
            }
            alt='프로필탭'
          />

![image](https://user-images.githubusercontent.com/107895498/210269964-673d2882-3ebb-4715-8684-4718a24a7d3e.png)


## [📢 Notice]

- 팔로잉리스트, 팔로워리스트 페이지 접속시 하단 탭 프로필 버튼 활성화
-
![image](https://user-images.githubusercontent.com/107895498/210268769-24707d5c-9ce7-4229-9962-db2b79aca467.png)
