### PR TITLE
<refact> : 홈피드 API 분리

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -144,17 +144,17 @@ const FetchApi = {
     return data;
   },
 
-  async loadFeed(token) {
-    const response = await fetch(`${BASE_URL}/post/feed`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-type': 'application/json',
-      },
-    });
-    const data = await response.json();
-    return data;
-  },
+  // async loadFeed(token) {
+  //   const response = await fetch(`${BASE_URL}/post/feed`, {
+  //     method: 'GET',
+  //     headers: {
+  //       Authorization: `Bearer ${token}`,
+  //       'Content-type': 'application/json',
+  //     },
+  //   });
+  //   const data = await response.json();
+  //   return data;
+  // },
 
   async registerProduct(reqData, token) {
     const response = await fetch(`${BASE_URL}/product`, {

--- a/src/api/postAPI.js
+++ b/src/api/postAPI.js
@@ -2,6 +2,18 @@ import BASE_URL from '../utils/baseUrl';
 
 // UserProfile 에서 사용됨
 const postAPI = {
+  async loadFeed(token) {
+    const response = await fetch(`${BASE_URL}/post/feed`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+    });
+    const data = await response.json();
+    return data;
+  },
+
   async getMyPost(token, pageAccount) {
     const response = await fetch(`${BASE_URL}/post/${pageAccount}/userpost`, {
       method: 'GET',

--- a/src/pages/HomeFeed/HomeFeed.jsx
+++ b/src/pages/HomeFeed/HomeFeed.jsx
@@ -7,7 +7,7 @@ import PostCard from '../../components/common/PostCard/PostCard';
 import symbolLogoMini from '../../assets/images/symbol-logo-mini.svg';
 import TabMenu from '../../components/common/TabMenu/TabMenu';
 import Nav from '../../components/Nav/Nav';
-import FetchApi from '../../api';
+import postAPI from '../../api/postAPI';
 import * as S from './StyledHomeFeed';
 
 const HomeFeed = () => {
@@ -18,7 +18,7 @@ const HomeFeed = () => {
 
   useEffect(() => {
     const setHomeFeed = async () => {
-      const data = await FetchApi.loadFeed(user.token);
+      const data = await postAPI.loadFeed(user.token);
       setFeed(data.posts);
       setIsLoading(false);
     };


### PR DESCRIPTION
# <refact> : 홈피드 API 분리

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/api/index.js
- src/api/postAPI.js
- src/pages/HomeFeed/HomeFeed.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 홈피드에 사용되는 API 코드를 기존에 작성된 api 폴더 내의 index.js에서 postAPI.js로 분리
  - index.js 내의 loadFeed 함수를 postAPI.js로 분리.
- 분리 후 테스트를 수행하여 정상적으로 작동하는지 확인함. 
- Close #199
