### PR TITLE
<feat> : 개별 채팅 페이지 UI 완성

### DIFF
--- a/src/components/Nav/ChatNav.jsx
+++ b/src/components/Nav/ChatNav.jsx
@@ -2,14 +2,14 @@ import * as S from './StyledNav';
 import MoreImg from '../../assets/images/icon-more-vertical.svg';
 import ArrowImg from '../../assets/images/icon-arrow-left.svg';
 
-const ChatNav = ({ handleReturn }) => {
+const ChatNav = ({ handleReturn, name }) => {
   return (
     <>
       {/* <h2 className='hidden'>채팅 페이지</h2> */}
       <button type='button' onClick={handleReturn}>
         <S.BackIcon src={ArrowImg} alt='뒤로가기버튼' />
       </button>
-      <S.HeaderTitle>대화 상대 닉네임</S.HeaderTitle>
+      <S.HeaderTitle>{name}</S.HeaderTitle>
       <button type='button'>
         <S.MoreIcon src={MoreImg} alt='더보기버튼' />
       </button>

--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -15,6 +15,7 @@ const Nav = ({
   disabled,
   followtitle,
   onClick,
+  name,
 }) => {
   const navigate = useNavigate();
   const handleReturn = () => {
@@ -33,7 +34,7 @@ const Nav = ({
         onClick={onClick}
       />
     ),
-    chat: <ChatNav handleReturn={handleReturn} />,
+    chat: <ChatNav handleReturn={handleReturn} name={name} />,
     follow: (
       <FollowHeader handleReturn={handleReturn} followtitle={followtitle} />
     ),

--- a/src/components/UserListItem/ChatUserList.jsx
+++ b/src/components/UserListItem/ChatUserList.jsx
@@ -1,19 +1,18 @@
 import { Link } from 'react-router-dom';
-import ChatRoom from '../../pages/ChatRoom/ChatRoom';
 import ProfileImg from '../../assets/images/profile-image-mini.svg';
 import * as S from './StyledUserListItem';
 
 const ChatUserList = ({ name, desc, time, chatid }) => {
   return (
     <S.ResultList>
-      <Link to={`/chatroom/${chatid}`} element={<ChatRoom />}>
+      <Link to={`/chatroom/${chatid}`} state={{ name, desc }}>
         <div>
           <S.UserprofileImg src={ProfileImg} alt='유저 프로필 이미지' />
         </div>
-        <div>
+        <S.UserBox>
           <S.UserName>{name}</S.UserName>
           <S.UserId>{desc}</S.UserId>
-        </div>
+        </S.UserBox>
         <S.ChatDate>{time}</S.ChatDate>
       </Link>
     </S.ResultList>

--- a/src/components/UserListItem/StyledUserListItem.jsx
+++ b/src/components/UserListItem/StyledUserListItem.jsx
@@ -24,6 +24,12 @@ export const UserprofileImg = styled.img`
   object-fit: cover;
 `;
 
+export const UserBox = styled.div`
+  width: 238px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
 export const UserName = styled.span`
   font-size: 1.4rem;
   font-weight: 500;

--- a/src/pages/ChatRoom/ChatRoom.jsx
+++ b/src/pages/ChatRoom/ChatRoom.jsx
@@ -1,10 +1,27 @@
+// import { useState } from 'react';
 import Nav from '../../components/Nav/Nav';
+import ProfileImg from '../../assets/images/profile-image-mini.svg';
+import * as S from './StyledChatRoom';
 
 const ChatRoom = () => {
   return (
-    <>
-      <Nav type='chat' />;
-    </>
+    <S.LayOut>
+      <Nav type='chat' />
+      <S.OtherUserChatBox>
+        <S.UserprofileImg src={ProfileImg} alt='유저 프로필 이미지' />
+        <S.OtherUserChatMsg>안녕하세요</S.OtherUserChatMsg>
+        <S.TimeMsg>12:39</S.TimeMsg>
+      </S.OtherUserChatBox>
+      <S.InputBox>
+        <S.ImgLabel htmlFor='이미지업로드' />
+        <input className='hidden' type='file' id='이미지업로드' />
+        <label htmlFor='chat' className='hidden'>
+          채팅창
+        </label>
+        <S.MsgInput id='chat' placeholder='메시지 입력하기' />
+        <S.ChatUploadBtn type='submit'>전송</S.ChatUploadBtn>
+      </S.InputBox>
+    </S.LayOut>
   );
 };
 

--- a/src/pages/ChatRoom/ChatRoom.jsx
+++ b/src/pages/ChatRoom/ChatRoom.jsx
@@ -1,15 +1,32 @@
-// import { useState } from 'react';
+import { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import Nav from '../../components/Nav/Nav';
 import ProfileImg from '../../assets/images/profile-image-mini.svg';
 import * as S from './StyledChatRoom';
 
 const ChatRoom = () => {
+  const location = useLocation();
+  // const name = location.state.name;
+  // const desc = location.state.desc;
+  const [chatMsg, setChatMsg] = useState('');
+  const [isValid, setIsValid] = useState(true);
+
+  // 1. input창에 글씨 보이기
+  const handleData = (e) => {
+    setChatMsg(e.target.value);
+  };
+
+  // 2. 1글자 이상이면 버튼 활성화
+  const handleCheckValid = () => {
+    return chatMsg.length > 0 ? setIsValid(false) : setIsValid(true);
+  };
+
   return (
     <S.LayOut>
-      <Nav type='chat' />
+      <Nav type='chat' name={location.state.name} />
       <S.OtherUserChatBox>
         <S.UserprofileImg src={ProfileImg} alt='유저 프로필 이미지' />
-        <S.OtherUserChatMsg>안녕하세요</S.OtherUserChatMsg>
+        <S.OtherUserChatMsg>{location.state.desc}</S.OtherUserChatMsg>
         <S.TimeMsg>12:39</S.TimeMsg>
       </S.OtherUserChatBox>
       <S.InputBox>
@@ -18,8 +35,16 @@ const ChatRoom = () => {
         <label htmlFor='chat' className='hidden'>
           채팅창
         </label>
-        <S.MsgInput id='chat' placeholder='메시지 입력하기' />
-        <S.ChatUploadBtn type='submit'>전송</S.ChatUploadBtn>
+        <S.MsgInput
+          id='chat'
+          placeholder='메시지 입력하기'
+          value={chatMsg}
+          onChange={handleData}
+          onKeyUp={handleCheckValid}
+        />
+        <S.ChatUploadBtn type='button' disabled={isValid}>
+          전송
+        </S.ChatUploadBtn>
       </S.InputBox>
     </S.LayOut>
   );

--- a/src/pages/ChatRoom/StyledChatRoom.jsx
+++ b/src/pages/ChatRoom/StyledChatRoom.jsx
@@ -1,0 +1,74 @@
+import styled from 'styled-components';
+import uploadBtnImg from '../../assets/images/img-button.svg';
+import { AllWrappCss } from '../../styles/Globalstyled';
+
+export const LayOut = styled.div`
+  ${AllWrappCss}
+  align-items: flex-start;
+  background-color: #f2f2f2;
+`;
+export const OtherUserChatBox = styled.div`
+  display: flex;
+  margin: 1.6rem;
+`;
+export const UserprofileImg = styled.img`
+  width: 4.2rem;
+  height: 4.2rem;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+export const OtherUserChatMsg = styled.p`
+  margin: 0 0 0 1.2rem;
+  padding: 1.2rem;
+  background: #fff;
+  border: 1px solid #c4c4c4;
+  border-radius: 0px 1rem 1rem;
+`;
+export const TimeMsg = styled.span`
+  align-self: end;
+  margin-left: 0.6rem;
+  font-size: 1.2rem;
+  color: #767676;
+`;
+export const InputBox = styled.form`
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 1.8rem;
+  padding: 1.2rem 1.6rem;
+  background: #fff;
+  border-top: 0.5px solid #dbdbdb;
+`;
+export const ImgLabel = styled.label`
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  background: no-repeat center/32px url(${uploadBtnImg});
+`;
+export const MsgInput = styled.input`
+  padding: 0 1rem;
+  width: 100%;
+  border: none;
+  font-size: 1.4rem;
+  &::placeholder {
+    color: #c4c4c4;
+    font-size: 1.4rem;
+    font-family: 'Spoqa Han Sans Neo', sans-serif;
+  }
+`;
+
+export const ChatUploadBtn = styled.button`
+  color: #f26e22;
+  font-size: 1.4rem;
+  line-height: 1.753rem;
+  font-weight: 500;
+  white-space: nowrap;
+
+  &.disabled {
+    pointer-events: none;
+    color: #c4c4c4;
+  }
+`;

--- a/src/pages/ChatRoom/StyledChatRoom.jsx
+++ b/src/pages/ChatRoom/StyledChatRoom.jsx
@@ -27,7 +27,8 @@ export const OtherUserChatMsg = styled.p`
 export const TimeMsg = styled.span`
   align-self: end;
   margin-left: 0.6rem;
-  font-size: 1.2rem;
+  font-size: 1rem;
+  line-height: 1.2rem;
   color: #767676;
 `;
 export const InputBox = styled.form`
@@ -66,8 +67,7 @@ export const ChatUploadBtn = styled.button`
   line-height: 1.753rem;
   font-weight: 500;
   white-space: nowrap;
-
-  &.disabled {
+  :disabled {
     pointer-events: none;
     color: #c4c4c4;
   }


### PR DESCRIPTION
# <feat> : 개별 채팅 페이지 UI 완성

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/components/Nav/ChatNav.jsx
- src/components/UserListItem/ChatUserList.jsx
- src/components/UserListItem/StyledUserListItem.jsx
- src/pages/ChatRoom/ChatRoom.jsx

## [📝 생성된 파일]

- src/pages/ChatRoom/StyledChatRoom.jsx

## [📌 제안 사항]

- chatData.json 파일 받아와서 ChatUserList 컴포넌트에 데이터를 props해주었음
- ChatUserList 컴포넌트에서 name, desc 를 ChatRoom 컴포넌트로 name,desc props로 전달
- ChatRoom 컴포넌트에서 Nav 컴포넌트로 name props전달
- Nav 컴포넌트에서 ChatNav 로 name props 전달
- props drilling 이 우려되어 추후 리팩토링시 보완해야함

## [📢 Notice]

- 채팅리스트에서 채팅 개별 페이지 클릭하면 채팅 더미데이터를 props로 받아와서 알맞은 데이터가 잘보이게함
- ChatUserList 컴포넌트 안 Link 태그에서 name,desc props를 아래와 같은 방법으로 전달해주었음
![image](https://user-images.githubusercontent.com/107895498/217196972-88f060e5-3627-47e3-b214-9bb458ff391c.png)
- ChatRoom 컴포넌트에서 props를 전달받았는데 전달 받을때는 useLocation을 써야한다.
![image](https://user-images.githubusercontent.com/107895498/217197529-cb176c17-85d9-4d40-89f7-c8f5f0300738.png)

![채팅개별페이지](https://user-images.githubusercontent.com/107895498/217196631-64375c22-8edd-4540-86fe-45532a8b55d4.gif)

