### PR TITLE
<Fix> : PostCard 영어 넘침 현상 수정

### DIFF
--- a/src/components/common/PostCard/StyledPostCard.jsx
+++ b/src/components/common/PostCard/StyledPostCard.jsx
@@ -58,6 +58,7 @@ export const PostContents = styled.div`
   font-size: 1.4rem;
   line-height: 1.8rem;
   /* gap: 16px; */
+  word-break: break-all;
   cursor: pointer;
 
   p {

--- a/src/components/common/PostCard/StyledPostCard.jsx
+++ b/src/components/common/PostCard/StyledPostCard.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-// import { Link } from 'react-router-dom';
 
 export const ContentsWrapper = styled.section`
   position: relative;
@@ -30,15 +29,6 @@ export const UserInfo = styled.div`
   position: relative;
   display: flex;
   justify-content: space-between;
-  /* button {
-    position: absolute;
-    width: 18px;
-    top: 0;
-    right: 0;
-    img {
-      width: 100%;
-    }
-  } */
 `;
 
 export const UserName = styled.h2`
@@ -57,7 +47,6 @@ export const UserAccount = styled.p`
 export const PostContents = styled.div`
   font-size: 1.4rem;
   line-height: 1.8rem;
-  /* gap: 16px; */
   word-break: break-all;
   cursor: pointer;
 


### PR DESCRIPTION
# <Fix> : PostCard 영어 넘침 현상 수정

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/components/common/PostCard/StyledPostCard.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- PostCard에 컨텐츠 내용을 영어로 입력 시 영어가 영역 밖으로 벗어나는 현상을 word-break 속성을 추가하여 수정하였습니다.
- 수정 전 PostCard
<img width="310" alt="image" src="https://user-images.githubusercontent.com/96678570/224470505-179e7372-40fb-46b0-a1ec-8eb8d23b450f.png">

- 수정 후 PostCard
<img width="310" alt="image" src="https://user-images.githubusercontent.com/96678570/224470526-ac213404-ddff-4f63-a2fa-9fe0c1025e65.png">

- PostCard 수정을 진행하면서 StyledPostCard.jsx 내의 불필요한 주석도 함께 삭제하였습니다.
