### PR TITLE
<Refact> : commentAPI 파일의 fetch 경로 수정

### DIFF
--- a/src/api/commentAPI.js
+++ b/src/api/commentAPI.js
@@ -1,7 +1,9 @@
+import BASE_URL from '../utils/baseUrl';
+
 const commnetAPI = {
   async deleteComment(token, postId, commentid) {
     const response = await fetch(
-      `https://mandarin.api.weniv.co.kr/post/${postId}/comments/${commentid}`,
+      `${BASE_URL}/post/${postId}/comments/${commentid}`,
       {
         method: 'DELETE',
         headers: {
@@ -16,7 +18,7 @@ const commnetAPI = {
 
   async reportComment(token, postId, commentid) {
     const response = await fetch(
-      `https://mandarin.api.weniv.co.kr/post/${postId}/comments/${commentid}/report`,
+      `${BASE_URL}/post/${postId}/comments/${commentid}/report`,
       {
         method: 'POST',
         headers: {

--- a/src/api/commentAPI.js
+++ b/src/api/commentAPI.js
@@ -1,6 +1,6 @@
 import BASE_URL from '../utils/baseUrl';
 
-const commnetAPI = {
+const commentAPI = {
   async deleteComment(token, postId, commentid) {
     const response = await fetch(
       `${BASE_URL}/post/${postId}/comments/${commentid}`,
@@ -32,4 +32,4 @@ const commnetAPI = {
   },
 };
 
-export default commnetAPI;
+export default commentAPI;

--- a/src/components/common/Modals/InnerModal.jsx
+++ b/src/components/common/Modals/InnerModal.jsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import commnetAPI from '../../../api/commentAPI';
+import commentAPI from '../../../api/commentAPI';
 import postAPI from '../../../api/postAPI';
 import productAPI from '../../../api/productAPI';
 import { AuthContext } from '../../../context/context';
@@ -50,7 +50,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       reportPost();
     } else if (name === '댓글삭제') {
       const deleteComment = async () => {
-        const data = await commnetAPI.deleteComment(
+        const data = await commentAPI.deleteComment(
           user.token,
           postId,
           comment.id,
@@ -63,7 +63,7 @@ const InnerModal = ({ name, CloseInnerModal, postId, productId, comment }) => {
       deleteComment();
     } else if (name === '댓글신고') {
       const reportComment = async () => {
-        const data = await commnetAPI.reportComment(
+        const data = await commentAPI.reportComment(
           user.token,
           postId,
           comment.id,


### PR DESCRIPTION
# <Refact> : commentAPI 파일의 fetch 경로 수정

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/api/commentAPI.js
- src/components/common/Modals/InnerModal.jsx

## [📝 생성된 파일]

- 없음.

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 기존에 적혀있던 fetch 경로를 아래와 같이 수정하였습니다.
  - `https://mandarin.api.weniv.co.kr/post/${postId}/comments/${commentid}` -> `${BASE_URL}/post/${postId}/comments/${commentid}`
- 객체 이름이 commnetAPI로 오타가 있어서 commentAPI로 수정하였으며, commentAPI를 import하고 있는 파일들도 모두 수정완료하였습니다.