### PR TITLE
<refact> : TanMenu 컴포넌트에서 myProfile탭 이동시 리랜더링 오류해결 

### DIFF
--- a/src/api/followAPI.js
+++ b/src/api/followAPI.js
@@ -1,0 +1,32 @@
+import BASE_URL from '../utils/baseUrl';
+
+const followAPI = {
+  async followingPost(token, pageAccount) {
+    const response = await fetch(`${BASE_URL}/profile/${pageAccount}/follow`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-type': 'application/json',
+      },
+    });
+    const data = await response.json();
+    return data;
+  },
+
+  async unfollowingPost(token, pageAccount) {
+    const response = await fetch(
+      `${BASE_URL}/profile/${pageAccount}/unfollow`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      },
+    );
+    const data = await response.json();
+    return data;
+  },
+};
+
+export default followAPI;

--- a/src/components/ProfileInfo/ProfileInfo.jsx
+++ b/src/components/ProfileInfo/ProfileInfo.jsx
@@ -1,45 +1,42 @@
 import { useLocation, Link } from 'react-router-dom';
-import { useState } from 'react';
+import { useContext } from 'react';
+import { ProfileDataContext } from '../../context/ProfileInfoContext';
 import * as S from './StyledProfileInfo';
 import UserProfileBtnWrap from './UserProfileBtnWrapp';
 import MyProfileBtnWrap from './MyProfileBtnWrapp';
 
-const ProfileInfo = ({ userProfile, authAccountName }) => {
+const ProfileInfo = ({ authAccountName }) => {
   const location = useLocation();
+  const { profile } = useContext(ProfileDataContext);
   const pageAccount = location.pathname.split('/')[2];
-  const [followerCnt, setFollowerCnt] = useState(userProfile.followerCount);
-  const [followingCnt, setFolloingCnt] = useState(userProfile.followingCount);
+
   return (
     <S.Container>
       <S.ProfileInfoWrapper>
         <h2 className='hidden'>프로필 정보</h2>
         <S.NumberWrapper>
           <Link to='followerlist'>
-            <span>{followerCnt}</span>
+            <span>{profile.followerCount}</span>
             <span>followers</span>
           </Link>
         </S.NumberWrapper>
-        <S.ProfileImg src={userProfile.image} alt='프로필 이미지' />
+        <S.ProfileImg src={profile.image} alt='프로필 이미지' />
         <S.NumberWrapper>
           <Link to='followinglist'>
-            <span>{followingCnt}</span>
+            <span>{profile.followingCount}</span>
             <span>followings</span>
           </Link>
         </S.NumberWrapper>
       </S.ProfileInfoWrapper>
       <S.UserWrapper>
-        <S.UserName>{userProfile.username}</S.UserName>
-        <S.UserId>{userProfile.accountname}</S.UserId>
-        <S.UserIntro>{userProfile.intro}</S.UserIntro>
+        <S.UserName>{profile.username}</S.UserName>
+        <S.UserId>{profile.accountname}</S.UserId>
+        <S.UserIntro>{profile.intro}</S.UserIntro>
       </S.UserWrapper>
       {pageAccount === authAccountName ? (
         <MyProfileBtnWrap />
       ) : (
-        <UserProfileBtnWrap
-          userProfile={userProfile}
-          setFollowerCount={setFollowerCnt}
-          setFolloingCount={setFolloingCnt}
-        />
+        <UserProfileBtnWrap />
       )}
     </S.Container>
   );

--- a/src/components/ProfileInfo/UserProfileBtnWrapp.jsx
+++ b/src/components/ProfileInfo/UserProfileBtnWrapp.jsx
@@ -1,27 +1,15 @@
-// import { useLocation } from 'react-router-dom';
-// import { useState, useContext } from 'react';
-// import Button from '../common/Button/Button';
 import FollowButton from '../common/Button/FollowButton';
-// import { AuthContext } from '../../context/context';
-import * as S from './StyledProfileInfo';
 import iconMessageCircle from '../../assets/images/icon-message-circle.svg';
 import iconShare from '../../assets/images/icon-share.svg';
+import * as S from './StyledProfileInfo';
 
-const UserProfileBtnWrapp = ({
-  userProfile,
-  setFolloingCount,
-  setFollowerCount,
-}) => {
+const UserProfileBtnWrapp = () => {
   return (
     <S.BtnWrapper>
       <S.Btn>
         <img src={iconMessageCircle} alt='메세지아이콘' />
       </S.Btn>
-      <FollowButton
-        userProfile={userProfile}
-        setFolloingCount={setFolloingCount}
-        setFollowerCount={setFollowerCount}
-      />
+      <FollowButton />
       <S.Btn>
         <img src={iconShare} alt='공유아이콘' />
       </S.Btn>

--- a/src/components/common/Button/FollowButton.jsx
+++ b/src/components/common/Button/FollowButton.jsx
@@ -9,7 +9,7 @@ const FollowButton = () => {
   const location = useLocation();
   const pageAccount = location.pathname.split('/')[2];
   const { user } = useContext(AuthContext);
-  const { profile } = useContext(ProfileDataContext);
+  const { profile, dispatch } = useContext(ProfileDataContext);
   const [isFollow, setIsFollow] = useState(profile.isfollow);
 
   useEffect(() => {
@@ -20,9 +20,19 @@ const FollowButton = () => {
     if (isFollow === false) {
       const data = await followAPI.followingPost(user.token, pageAccount);
       setIsFollow(data.profile.isfollow);
+      const FollowData = { ...data.profile };
+      dispatch({
+        type: 'FOLLOW_COUNT',
+        payload: FollowData.followerCount,
+      });
     } else if (isFollow === true) {
       const data = await followAPI.unfollowingPost(user.token, pageAccount);
+      const FollowData = { ...data.profile };
       setIsFollow(data.profile.isfollow);
+      dispatch({
+        type: 'FOLLOW_COUNT',
+        payload: FollowData.followerCount,
+      });
     }
   };
   return !isFollow ? (

--- a/src/components/common/Button/FollowButton.jsx
+++ b/src/components/common/Button/FollowButton.jsx
@@ -1,48 +1,28 @@
 import { useLocation } from 'react-router-dom';
-import { useState, useContext } from 'react';
-import Button from './Button';
+import { useState, useContext, useEffect } from 'react';
 import { AuthContext } from '../../../context/context';
+import { ProfileDataContext } from '../../../context/ProfileInfoContext';
+import Button from './Button';
+import followAPI from '../../../api/followAPI';
 
-const FollowButton = ({ userProfile, setFolloingCount, setFollowerCount }) => {
+const FollowButton = () => {
   const location = useLocation();
-  const [isFollow, setIsFollow] = useState(userProfile.isfollow);
   const pageAccount = location.pathname.split('/')[2];
   const { user } = useContext(AuthContext);
-  const BASE_URL = 'https://mandarin.api.weniv.co.kr';
+  const { profile } = useContext(ProfileDataContext);
+  const [isFollow, setIsFollow] = useState(profile.isfollow);
 
-  const handelIsFollow = () => {
+  useEffect(() => {
+    setIsFollow(profile.isfollow);
+  }, [profile.isfollow]);
+
+  const handelIsFollow = async () => {
     if (isFollow === false) {
-      const followingPost = async () => {
-        const url = `${BASE_URL}/profile/${pageAccount}/follow`;
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${user.token}`,
-            'Content-type': 'application/json',
-          },
-        });
-        const data = await response.json();
-        setIsFollow(data.profile.isfollow);
-        setFolloingCount(data.profile.followingCount);
-        setFollowerCount(data.profile.followerCount);
-      };
-      followingPost();
+      const data = await followAPI.followingPost(user.token, pageAccount);
+      setIsFollow(data.profile.isfollow);
     } else if (isFollow === true) {
-      const unfollowingPost = async () => {
-        const url = `${BASE_URL}/profile/${pageAccount}/unfollow`;
-        const response = await fetch(url, {
-          method: 'DELETE',
-          headers: {
-            Authorization: `Bearer ${user.token}`,
-            'Content-type': 'application/json',
-          },
-        });
-        const data = await response.json();
-        setIsFollow(data.profile.isfollow);
-        setFolloingCount(data.profile.followingCount);
-        setFollowerCount(data.profile.followerCount);
-      };
-      unfollowingPost();
+      const data = await followAPI.unfollowingPost(user.token, pageAccount);
+      setIsFollow(data.profile.isfollow);
     }
   };
   return !isFollow ? (

--- a/src/components/common/Product/ProductWrapp.jsx
+++ b/src/components/common/Product/ProductWrapp.jsx
@@ -9,14 +9,14 @@ const ProductWrapp = ({ pageAccount }) => {
   const { user } = useContext(AuthContext);
 
   // 판매중인 상품페이지에 상품 불러오기
-  // 화면에 첫 렌더링될때만 서버통신 실행
+  // PageAccount가 변경될 때 렌더링될 수 있도록 서버통신
   useEffect(() => {
     const setProductFeed = async () => {
       const data = await productAPI.loadProductFeed(user.token, pageAccount);
       setProductList(data.product);
     };
     setProductFeed();
-  }, []);
+  }, [pageAccount]);
 
   return productList.length > 0 ? (
     <ProductSection>

--- a/src/context/ProfileInfoContext.js
+++ b/src/context/ProfileInfoContext.js
@@ -1,0 +1,32 @@
+import { createContext, useReducer, useMemo } from 'react';
+
+// 컨텍스트 공간 생성
+const ProfileDataContext = createContext();
+const ProfileDataReducer = (state, action) => {
+  switch (action.type) {
+    case 'USERINFO_DATA':
+      return { ...state, profile: action.payload };
+    case 'FOLLOW_COUNT':
+      return {
+        ...state,
+        profile: { ...state.profile, followerCount: action.payload },
+      };
+    default:
+      return state;
+  }
+};
+
+const InitioalState = { profile: {} };
+
+const ProfileDataContextProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(ProfileDataReducer, InitioalState);
+  const value = useMemo(() => ({ ...state, dispatch }), [state]);
+
+  return (
+    <ProfileDataContext.Provider value={value}>
+      {children}
+    </ProfileDataContext.Provider>
+  );
+};
+
+export { ProfileDataContext, ProfileDataContextProvider };

--- a/src/context/ProfileInfoContext.js
+++ b/src/context/ProfileInfoContext.js
@@ -1,6 +1,6 @@
 import { createContext, useReducer, useMemo } from 'react';
 
-// 컨텍스트 공간 생성
+// Context 저장공간 생성
 const ProfileDataContext = createContext();
 
 const ProfileDataReducer = (state, action) => {
@@ -16,12 +16,14 @@ const ProfileDataReducer = (state, action) => {
       return state;
   }
 };
-
+// 초기상태
 const InitioalState = { profile: {} };
 
+// Provider 함수
 const ProfileDataContextProvider = ({ children }) => {
   const [state, dispatch] = useReducer(ProfileDataReducer, InitioalState);
   const value = useMemo(() => ({ ...state, dispatch }), [state]);
+  // useMemo 함수를 활용하여 의존성배열에 state (== initialState) 추가하여 해당 state의 변화만 감지할 수 있도록 하였음.
 
   return (
     <ProfileDataContext.Provider value={value}>

--- a/src/context/ProfileInfoContext.js
+++ b/src/context/ProfileInfoContext.js
@@ -2,6 +2,7 @@ import { createContext, useReducer, useMemo } from 'react';
 
 // 컨텍스트 공간 생성
 const ProfileDataContext = createContext();
+
 const ProfileDataReducer = (state, action) => {
   switch (action.type) {
     case 'USERINFO_DATA':

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { AuthContextProvider } from './context/context';
+import { ProfileDataContextProvider } from './context/ProfileInfoContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <AuthContextProvider>
-      <App />
+      <ProfileDataContextProvider>
+        <App />
+      </ProfileDataContextProvider>
     </AuthContextProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
# TanMenu 컴포넌트에서 myProfile탭 이동시 리랜더링 오류해결 

## [⚠️ 삭제된 파일 ]

- 없음.

## [✂️ 수정된 파일]

- src/index.jsx
- src/components/ProfileInfo/ProfileInfo.jsx
- src/components/ProfileInfo/UserProfileBtnWrapp.jsx
- src/components/common/Button/FollowButton.jsx
- src/pages/Profile/UserProfile/UserProfile.jsx
- src/components/common/Product/ProductWrapp.jsx

## [📝 생성된 파일]

- src/api/followAPI.js
- src/context/ProfileInfoContext.js

## [📌 제안 사항]

- 없음.

## [📢 Notice]

- 에러 발생상황 1
   * 타유저의 '프로필 페이지' 에서 하단에 위치한 'TabMenu' 컴포넌트를 통해 '나의 프로필 페이지' 탭으로 이동 후, 뒤로가기 또는 타 유저의
      '프로필 페이지' 이동시 해당 유저(타유저 또는 로그인한 유저)에 맞는 프로필 페이지가 렌더링 되지 않았음.
   * UserProfile(최 상위) -> profileInfo -> UserProfileBtnWrap -> FollowButton(최 하위) 와 같은 파일 구조로 UserProfile 컴포넌트 에서 서버통신을 통해 받아온 데이터를 props를 통해 최 하위 컴포넌트 까지 전달하였음. props driling 과 컴포넌트의 데이터 구조 복잡도가 올라갔음.
   * 컴포넌트 복잡도와 props를 통한 데이터를 전달로 인해 UserProfile 컴포넌트의 state 변화 의존도가 집중되어있어 문제가 발생했다고 판단하였음.
 
- 에러 발생상황1 해결방안
   * UserProfile 컴포넌트에 작성된 서버통신 코드(fetch code)의 동작 조건이 복잡하다고 판단함.
   * 타유저 또는 로그인유저 프로필 페이지 이동시 pageAccount가 변경되는 것을 활용하여, UserProfile 컴포넌트에서 fetch code를 useEffect hook 내부에 작성하고, 의존성 배열에 pageAccount(현재 화면에 보여지고 있는 유저의 Accountname)를 추가 하였음.  AccountName에 맞는 데이터를 리랜더링 할 수 있도록 수정하였음.
      <img width="538" alt="image" src="https://user-images.githubusercontent.com/89332492/232527760-ee3f6c56-e101-4d78-87c6-c017b28aec28.png">

   * UserProfile 컴포넌트에서 fetch 코드를 전역 데이터로 관리할 수 있도록 useContext + useReducer + useMemo hook을 활용 하였음.
   * UserProfile 컴포넌트에서 서버통신과 동시에 dispatch를 사용하여 전역 데이터 저장소인 ProfileInfoContext에  저장시킴.
   * useContext + useReducer를 활용해 UserProfile 에 몰려 있던 state 변화 의존도를 분산 시킬 수 있었음.
   * useMemo 함수를 활용하여 의존성 배열에 state (== initialState)를 추가하여 dispatch를 통해 전달 받은 payload data가 reducer를 통해 반환된 데이터를 initialState에 저장되면서, state의 변화를 감지하고 리랜더링 될 수 있는 효율적인 코드로 수정하였음.
      <img width="646" alt="image" src="https://user-images.githubusercontent.com/89332492/232533736-d20eb161-1fbf-4699-ab87-e8c4495f0df7.png">



- 에러 발생상황2
   * 타유저와 팔로우 관계를 맺는 '팔로우' 버튼 클릭시 프로필 페이지에 그려진 followerCount 숫자가 실시간 리랜더링이 되지 않음.
   * 타유저 프로필 페이지에서 뒤로가기 또는 페이지 이동 후 다시 프로필 페이지로 돌아왔을 때, '팔로우' 버튼상태가 해당유저와의 isFollow 상태와 상관없이 false 상태로 유지되어 있음.
   * false 상태로 유지되어 있던 이유는 UserProfile 컴포넌트에서 dispatch를 통해 전송한 '로그인한 유저'의 데이터를 전송했기 때문에 isFollow가 false로 저장되어 있었음.

- 에러 발생상활2 해결방안
   * setIsFollow의 초깃값을 ProfileInfoContext에서 불러온 profile.isfollow으로 설정하였기 때문에 먼저 false 값을 불러오면서 FollowButton이 로그인한유저와의 팔로우 관계와 상관없이 '팔로우' 버튼으로 고정되어 있음을 확인.
   * FollowButton 컴포넌트에서 '팔로우' 버튼 클릭 이벤트가 발생할 때, 서버통신과 동시에 전역상태관리가 될 수 있도록 dispatch에 담아 context에 저장하여, followerCount 상태를 받아올 수 있도록 하였음.
   *  isFollow 상태를 조작할 수 있는 setIsFollow 함수를 useEffect hook 내부에 작성하고 의존성 배열에 ProfileInfoContext에서 불러온 profile.isfollow 데이터를 감시할 수 있도록 하여 정확한 isFollow 데이터가 로드될 수 있도록 하였음.
   <img width="678" alt="image" src="https://user-images.githubusercontent.com/89332492/232539355-67aacf19-a951-4c5d-9863-478382d98489.png">

